### PR TITLE
docs: add agent ops cycle to ai-agent-workflow

### DIFF
--- a/docs/engineering-practices/ai-agent-workflow.md
+++ b/docs/engineering-practices/ai-agent-workflow.md
@@ -3,20 +3,20 @@
 **Scope:** All engineers and AI agents working in this repository.
 **Last updated:** 2026-04-24
 
----
-
-## Why Guardrails Matter More for AI-Generated Code
-
-A human engineer typically opens a few PRs per day. An AI agent can open many PRs in rapid succession. Even a small error rate (say, 5%) becomes a real problem at volume — one broken change every twenty PRs reaching production without checks is unacceptable.
-
-Guardrails exist so that:
-- **Objective failures** (type errors, broken builds, schema drift) are caught automatically, without human effort
-- **Human review** focuses on what only a human can judge: intent, logic, design quality
-- **The combination** — automated checks + human approval — is stronger than either alone
+> **Note on CI tooling:** The inner loop diagram shows frontend tools (Husky, ESLint, TypeScript, Vitest). Backend uses pre-commit framework, Black, Flake8, and pytest. The phases and principles are identical — only the tool names differ. When the repo splits, each team copies this file and updates the tool names for their stack.
 
 ---
 
-## Full Guardrail Chain — Development to Production
+## Two Loops, Not One
+
+The agent participates in two distinct cycles:
+
+- **Inner loop — Execution:** A task is assigned. The agent writes code, opens a PR, CI runs, human reviews, merges. Linear flow from development to production.
+- **Outer loop — Operations:** The agent monitors production signals, researches context, and proposes work without being explicitly assigned. A continuous cycle that feeds back into the inner loop.
+
+---
+
+## Inner Loop — Development to Production
 
 ```mermaid
 sequenceDiagram
@@ -34,9 +34,9 @@ sequenceDiagram
     rect rgb(220, 235, 255)
         note over Dev, Branch: Phase 1 — Local Development
         Dev->>Local: git commit
-        Local->>Local: Husky pre-commit hook fires
-        Local->>Local: lint-staged — ESLint + Prettier on staged .ts/.tsx only
-        alt Lint or format fails
+        Local->>Local: Pre-commit hook fires
+        Local->>Local: Lint and format check on staged files only
+        alt Fails
             Local-->>Dev: Commit rejected — fix before committing
         else Passes
             Local-->>Dev: Commit accepted
@@ -47,31 +47,31 @@ sequenceDiagram
     rect rgb(255, 243, 220)
         note over Branch, GH: Phase 2 — Pull Request
         Dev->>GH: Opens PR  feature/task-name to main
-        note over GH: Branch protection rules active<br/>CI must pass before merge<br/>1 human approval required<br/>No direct push to main<br/>Stale approval dismissed on new push
+        note over GH: Branch protection rules<br/>CI must pass before merge<br/>1 human approval required<br/>No direct push to main<br/>Stale approval dismissed on new push
         GH->>CI: Triggers ci.yml on pull_request event
     end
 
     rect rgb(220, 255, 220)
-        note over CI: Phase 3 — CI Checks (GitHub Actions)
-        CI->>CI: npm run build — TypeScript compile and Vite bundle
-        CI->>CI: npm run lint — ESLint across whole project
-        CI->>CI: npm test — Vitest unit tests
-        CI->>CI: Future 3.16.7 — Schema validator GraphQL fields vs openapi.json
-        CI->>CI: Future 3.16.8 — graphql-inspector breaking schema changes vs main
+        note over CI: Phase 3 — CI Checks
+        CI->>CI: Build check — compile and bundle
+        CI->>CI: Lint check — whole project
+        CI->>CI: Test suite
+        CI->>CI: Future — Schema validator
+        CI->>CI: Future — graphql-inspector
         alt Any check fails
             CI-->>GH: Status FAILED
             GH-->>Human: Red cross on PR — merge button locked
             Human->>Dev: Investigate failure in Actions tab
-            Dev->>Branch: Push fix — CI re-triggers, concurrency cancels old run
+            Dev->>Branch: Push fix — CI re-triggers
         else All checks pass
             CI-->>GH: Status PASSED
-            GH-->>Human: Green tick — merge unlocked, ready for review
+            GH-->>Human: Green tick — merge unlocked
         end
     end
 
     rect rgb(255, 245, 220)
         note over Human, Main: Phase 4 — Human Review
-        Human->>Human: Reviews intent, logic, design — things CI cannot check
+        Human->>Human: Reviews intent, logic, design
         alt Changes requested
             Human-->>Dev: Review comment on PR
             Dev->>Branch: Push fix — CI re-triggers
@@ -90,17 +90,64 @@ sequenceDiagram
     end
 
     rect rgb(220, 245, 255)
-        note over Prod, Monitor: Phase 6 — Production Monitoring (always on)
-        Monitor->>Prod: Canary tests every 50 min — health, menu, delivery endpoints
+        note over Prod, Monitor: Phase 6 — Production Monitoring
+        Monitor->>Prod: Canary tests every 50 min
         alt Canary fails
-            Monitor->>GH: Auto-opens issue with label canary-failure
+            Monitor->>GH: Auto-opens issue — canary-failure label
             GH-->>Human: Email notification
         else Canary recovers
             Monitor->>GH: Auto-closes canary-failure issue
         end
-        Prod-->>Monitor: Runtime errors captured by Sentry — frontend, backend, gateway
+        Prod-->>Monitor: Runtime errors captured by Sentry
     end
 ```
+
+---
+
+## Outer Loop — Agent Operations Cycle
+
+The agent does not only execute assigned tasks. It monitors three signal sources continuously and one on a schedule, researches context from multiple sources, and proposes work proactively. Every proposal feeds back into the inner loop.
+
+```mermaid
+flowchart TD
+    subgraph Signals["Signal Sources"]
+        S1["🔴 Sentry\nError spike or new unhandled exception\nin frontend, backend, or gateway"]
+        S2["🟡 Canary failure\nEndpoint returning errors or timing out\ndetected every 50 min"]
+        S3["🔵 New GitHub Issue\nOpened by human, by canary auto-open,\nor escalated by a previous agent run"]
+        S4["🟢 Scheduled review\nPeriodic agent run — scans for\nerror patterns, tech debt, doc drift"]
+    end
+
+    S1 & S2 & S3 & S4 --> A[Agent picks up signal]
+
+    subgraph Research["Investigation Phase"]
+        A --> B1["Read Sentry logs\nStack traces, error frequency,\naffected users"]
+        A --> B2["Read source files\nFiles referenced in stack trace\nor issue description"]
+        A --> B3["Search historical GitHub Issues\nSame or similar error patterns\nfrom the past"]
+        A --> B4["Read documentation and ADRs\nArchitecture decisions, known constraints,\nprevious fix attempts"]
+    end
+
+    B1 & B2 & B3 & B4 --> C{Agent confidence}
+
+    C -->|"High\nRoot cause clear,\nfix is bounded"| D["Create feature branch\nWrite fix\nOpen Draft PR with full diagnosis"]
+    C -->|"Medium\nLikely cause known,\nneeds human judgement"| E["Create GitHub Issue\nWith diagnosis, stack trace,\nand proposed approaches"]
+    C -->|"Low\nComplex or cross-cutting,\nneeds design decision"| F["Create GitHub Issue\nWith full analysis\nRequest human design input"]
+
+    D --> G["Back to inner loop\nCI checks → Human Review → Merge"]
+    E --> H["Human picks up issue\nAssigns or resolves"]
+    F --> H
+```
+
+---
+
+## Signal Sources Explained
+
+| Signal | What triggers it | What the agent reads |
+|---|---|---|
+| **Sentry error spike** | Error rate exceeds threshold or new unhandled exception | Stack trace, source file at the line, recent commits that may have introduced it |
+| **Sentry new error type** | Error class never seen before in production | Where in the codebase this originates, whether tests cover the scenario |
+| **Canary failure** | Health, menu, or delivery endpoint fails or times out | Backend logs, recent deployments, historical canary failures for the same endpoint |
+| **New GitHub Issue** | Human reports a bug, canary auto-opens, or agent escalates | Issue description, historical issues for similar reports, relevant source files |
+| **Scheduled review** | Periodic run | Stale TODOs, test gaps, documentation drift vs current code, recurring error patterns |
 
 ---
 
@@ -108,28 +155,37 @@ sequenceDiagram
 
 | Layer | Catches | Does not catch |
 |---|---|---|
-| Pre-commit (Husky) | Lint errors and formatting on staged files only | Type errors, build failures, whole-project issues |
-| CI — build | TypeScript compile errors, broken imports, missing modules | Runtime logic errors |
-| CI — lint | ESLint violations across the whole project | Issues in files not covered by lint rules |
+| Pre-commit | Lint and format errors on staged files | Type errors, build failures, whole-project issues |
+| CI — build | Compile errors, broken imports, missing modules | Runtime logic errors |
+| CI — lint | Lint violations across the whole project | Issues outside lint rule coverage |
 | CI — tests | Unit test regressions | Integration failures, end-to-end behaviour |
-| CI — schema validator *(future)* | GraphQL fields not present in backend openapi.json | Runtime data shape mismatches |
+| CI — schema validator *(future)* | GraphQL fields missing from backend openapi.json | Runtime data shape mismatches |
 | CI — graphql-inspector *(future)* | Breaking GraphQL schema changes vs main | Non-breaking drift |
-| Human review | Intent problems, logic errors, design issues | Anything automated checks already covered |
+| Human review | Intent, logic, and design problems | Anything automated checks already cover |
 | Canary + Sentry | Production runtime failures | Pre-production issues |
+| **Agent ops loop** | **Error trends, recurring bugs, doc drift — patterns CI cannot see** | **Issues requiring human design judgement** |
 
 ---
 
 ## Recommended Behaviour for a GenAI Agent
 
-1. **Create a feature branch per task** — never commit directly to `main`
-2. **Batch all changes for a task into one PR** — do not open a PR per commit
-3. **Open as Draft PR if work is incremental** — get CI feedback without triggering a review
-4. **Wait for CI to pass before requesting human review** — do not request review on a failing PR
-5. **Address CI failures before pushing a new commit** — do not push workarounds; fix the root cause
-6. **One task, one PR, one review cycle** — keeps the review queue manageable for the human
+**When executing an assigned task (inner loop):**
+1. Pull `main` before branching — never branch from stale code
+2. Create a feature branch per task — never commit directly to `main`
+3. Batch all changes for a task into one PR — one task, one PR, one review cycle
+4. Open as Draft PR if work is incremental — get CI feedback before requesting review
+5. Wait for CI to pass before requesting human review
+6. Fix the root cause of CI failures — do not push workarounds
+
+**When operating autonomously (outer loop):**
+1. Always read historical issues before proposing a fix — the pattern may be known
+2. Always read the relevant source files — do not propose changes based on issue title alone
+3. Open a Draft PR for bounded fixes; open a GitHub Issue for anything requiring human judgement
+4. Include your full diagnosis in the PR or issue — the human should not have to re-investigate
+5. Never merge without human approval — the outer loop proposes, the human decides
 
 ---
 
 ## Note on Future Repo Split
 
-When frontend and backend are separated into independent repositories, each team maintains their own copy of this document, updated to reflect their specific CI checks and deploy pipeline. The principles — automated gates before human review, human review before merge, monitoring after deploy — remain the same.
+When frontend and backend move to separate repositories, each team copies this file and updates the CI tool names in the inner loop diagram for their stack. The two-loop structure, signal sources, investigation phase, and agent behaviour rules apply equally to both teams.


### PR DESCRIPTION
Adds outer loop diagram showing how the agent monitors Sentry errors, canary failures, GitHub issues, and scheduled reviews to proactively propose fixes. Clarifies inner loop CI tooling is frontend-specific.