### PR TITLE
feat: add GraphQL schema validator and CI schema drift checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,12 @@ jobs:
         run: npm ci
 
       - name: Validate GraphQL schema
-        run: node graphql-gateway/scripts/validate-schema.js
+        # Run against every schema file so new features are not silently skipped.
+        # Previously this ran only against menu.graphql (the default), so orders/reservations/delivery were never checked.
+        run: |
+          for schema in graphql-gateway/schemas/*.graphql; do
+            SCHEMA_PATH=$schema node graphql-gateway/scripts/validate-schema.js
+          done
 
       - name: Check for breaking GraphQL schema changes
         run: |

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,16 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Validate GraphQL Schema",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/graphql-gateway/scripts/validate-schema.js",
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "SCHEMA_PATH": "graphql-gateway/schemas/menu.graphql"
+      }
+    },
+    {
       "name": "FastAPI — Debug Backend",
       "type": "debugpy",
       "request": "launch",

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -93,13 +93,16 @@ class StripeWebhookPayload(BaseModel):
 ## Exception Handling Rules
 
 - **Always use `except Exception as e`** — never bare `except Exception:`. Without `as e` the error is invisible in the debugger and in logs.
-- **Always log the exception before returning a generic response** — `print(f"[router_name] unexpected error: {e}")`. Without this a 503 in production leaves no trace in Render logs — the only signal is a status code with no root cause.
+- **Always log the exception before returning a generic response** — `logger.exception("[router_name] unexpected error")`. This captures the full stack trace and `request_id` automatically. Without this a 503 in production leaves no trace — the only signal is a status code with no root cause. See `docs/engineering-practices/logging-strategy.md` for the full logging strategy.
 - **Never swallow exceptions silently in service calls** — if a service raises, let it propagate to the router where it gets logged and handled consistently.
 
 ```python
 # ✅ correct pattern
+import logging
+logger = logging.getLogger(__name__)
+
 except Exception as e:
-    print(f"[menu] unexpected error: {e}")
+    logger.exception("[menu] unexpected error")
     return JSONResponse(status_code=503, content={...})
 
 # ❌ wrong — error invisible in debugger and Render logs

--- a/backend/routers/catering.py
+++ b/backend/routers/catering.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
@@ -8,7 +10,7 @@ from services.config_service import get_restaurant_config
 from core.rate_limit import limiter
 
 router = APIRouter(prefix="/api")
-
+logger = logging.getLogger(__name__)
 
 @router.post("/catering")
 @limiter.limit("20/minute")
@@ -19,7 +21,7 @@ async def catering_create(
         config = await get_restaurant_config(db)
         return await create_catering_order(db, body, config)
     except Exception as e:
-        print(f"[catering] unexpected error: {e}")
+        logger.exception("[catering] unexpected error")
         return JSONResponse(
             status_code=503,
             content={

--- a/backend/routers/delivery.py
+++ b/backend/routers/delivery.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
@@ -5,6 +7,7 @@ from core.database import get_db
 from models.delivery import DeliveryValidateRequest, DeliveryValidateResponse
 import services.delivery_service as delivery_service
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api")
 
 
@@ -16,7 +19,7 @@ async def validate_delivery_zip(request: DeliveryValidateRequest, db=Depends(get
             return DeliveryValidateResponse(is_covered=True, city=result["city"])
         return DeliveryValidateResponse(is_covered=False, city=None)
     except Exception as e:
-        print(f"[delivery] unexpected error: {e}")
+        logger.exception("[delivery] unexpected error:")
         return JSONResponse(
             status_code=503,
             content={

--- a/backend/routers/health.py
+++ b/backend/routers/health.py
@@ -1,7 +1,10 @@
+import logging
+
 from fastapi import APIRouter
 from core.database import get_pool
 from fastapi.responses import JSONResponse
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
@@ -13,7 +16,7 @@ async def health_check():
             await conn.fetchval("SELECT 1")
         return {"status": "ok"}
     except Exception as e:
-        print(f"[health] database unreachable: {e}")
+        logger.exception("[health] database unreachable")
         return JSONResponse(
             status_code=503,
             content={"status": "unavailable"},

--- a/backend/routers/menu.py
+++ b/backend/routers/menu.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
@@ -6,6 +8,7 @@ from models.menu import MenuResponse
 import services.menu_service as menu_service
 
 router = APIRouter(prefix="/api")
+logger = logging.getLogger(__name__)
 
 
 @router.get("/menu", response_model=MenuResponse)
@@ -14,7 +17,7 @@ async def get_menu(db=Depends(get_db)):
         rows = await menu_service.get_menu_items(db)
         return menu_service.group_by_category(rows)
     except Exception as e:
-        print(f"[menu] unexpected error: {e}")
+        logger.exception("[menu] unexpected error")
         return JSONResponse(
             status_code=503,
             content={

--- a/backend/routers/orders.py
+++ b/backend/routers/orders.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 from core.database import get_db
@@ -6,6 +8,7 @@ from services.config_service import get_restaurant_config
 from services.order_service import create_order
 from core.rate_limit import limiter
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api")
 
 
@@ -19,7 +22,7 @@ async def order_create(request: Request, body: OrderCreateRequest, db=Depends(ge
     except HTTPException:
         raise
     except Exception as e:
-        print(f"[orders] unexpected error: {e}")
+        logger.exception("[orders] unexpected error")
         return JSONResponse(
             status_code=503,
             content={

--- a/backend/routers/reservations.py
+++ b/backend/routers/reservations.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
@@ -7,6 +9,7 @@ from services.config_service import get_restaurant_config
 from services.reservation_service import create_reservation
 from core.rate_limit import limiter
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api")
 
 
@@ -22,7 +25,7 @@ async def reservation_create(
     except HTTPException:
         raise
     except Exception as e:
-        print(f"[reservations] unexpected error: {e}")
+        logger.exception("[reservations] unexpected error")
         return JSONResponse(
             status_code=503,
             content={

--- a/backend/services/catering_service.py
+++ b/backend/services/catering_service.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import date, datetime, timedelta
 
 from fastapi.responses import JSONResponse
@@ -8,6 +9,8 @@ from core.timezone import now_in_restaurant_time
 from services.delivery_service import validate_zip
 from services.reference_service import generate_reference_number
 from services.notification_service import notify_catering
+
+logger = logging.getLogger(__name__)
 
 
 async def fetch_catering_items(db, items: list) -> list[dict]:
@@ -177,6 +180,10 @@ async def create_catering_order(db, payload, config: dict) -> JSONResponse:
         )
 
     # --- Fire notifications (failures are logged, never block the response) ---
+    logger.info(
+        "[catering] catering order created — reference: %s", reference_number,
+        extra={"event": "catering_order_created", "reference": reference_number},
+    )
     await notify_catering(
         {
             "reference_number": reference_number,

--- a/backend/services/order_service.py
+++ b/backend/services/order_service.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, date
 from zoneinfo import ZoneInfo
 
@@ -10,6 +11,8 @@ from services.notification_service import notify_order
 from services.delivery_service import validate_zip
 from services.menu_service import validate_menu_items
 from services.reference_service import generate_reference_number
+
+logger = logging.getLogger(__name__)
 
 
 def validate_scheduled_time(
@@ -207,6 +210,10 @@ async def create_order(db, payload, config: dict) -> JSONResponse:
         )
 
     # Step 9 — fire notifications (failures are logged, never block the response)
+    logger.info(
+        "[orders] order created — reference: %s", reference_number,
+        extra={"event": "order_created", "reference": reference_number},
+    )
     await notify_order(
         {
             "reference_number": reference_number,

--- a/backend/services/reservation_service.py
+++ b/backend/services/reservation_service.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, date
 from zoneinfo import ZoneInfo
 
@@ -8,6 +9,8 @@ from core.errors import error_response
 from core.timezone import now_in_restaurant_time
 from services.notification_service import notify_reservation
 from services.reference_service import generate_reference_number
+
+logger = logging.getLogger(__name__)
 
 
 def validate_reservation_time(
@@ -118,6 +121,10 @@ async def create_reservation(db, payload, config: dict) -> JSONResponse:
     )
 
     # Step 5 — fire notifications (failures are logged, never block the response)
+    logger.info(
+        "[reservations] reservation confirmed — reference: %s", reference_number,
+        extra={"event": "reservation_confirmed", "reference": reference_number},
+    )
     await notify_reservation(
         {
             "reference_number": reference_number,

--- a/docs/engineering-practices/logging-strategy.md
+++ b/docs/engineering-practices/logging-strategy.md
@@ -1,0 +1,170 @@
+# Logging Strategy
+
+## Purpose
+
+This document defines the logging standard for the Aap ki Rasoi backend.
+It serves two audiences: a new engineer learning the codebase, and a GenAI
+agent generating or debugging backend code. Both must be able to follow
+these rules without ambiguity.
+
+---
+
+## The Stack
+
+| Layer | What it does |
+|---|---|
+| Python `logging` module | Standard library logger — all code imports from here |
+| `pythonjsonlogger` | Formats log lines as JSON in production, human-readable in dev |
+| `RequestIdFilter` | Stamps every log line with `request_id` from the current request context |
+| `setup_logging()` | Called once at startup in `main.py` — configures format and handler |
+
+Every log line automatically carries: `asctime`, `levelname`, `name` (module),
+`message`, `request_id`. You never add these manually.
+
+---
+
+## Import Pattern
+
+Every file that needs a logger uses this exact pattern:
+
+```python
+import logging                              # stdlib — always first import group
+
+logger = logging.getLogger(__name__)       # module-level, after imports
+```
+
+`__name__` gives each module its own logger name (e.g. `routers.orders`,
+`services.order_service`), which appears in the `name` field of every log line.
+
+---
+
+## Layer Rules
+
+### Routers — exception logging only
+
+Routers log failures. They do not log success — the middleware already records
+every request with method, path, status code, and duration.
+
+```python
+except Exception as e:
+    logger.exception("[orders] failed to create order")
+    return JSONResponse(status_code=503, ...)
+```
+
+Rules:
+- Always use `logger.exception()` — captures full stack trace automatically
+- Message format: `[router_name] failed to <operation>` — name the operation,
+  never just "unexpected error"
+- No `extra={}` needed — routers are infrastructure, not business events
+
+### Core Business Services — success events
+
+Every service function that creates a business record must log a success event
+with the reference number. This is the audit trail.
+
+```python
+logger.info(
+    "[orders] order created — reference: %s", reference,
+    extra={"event": "order_created", "reference": reference}
+)
+```
+
+Rules:
+- Use both prose (human-readable in Render) and `extra={}` (machine-parseable
+  for GenAI agents and structured log queries)
+- Always include `reference` in `extra` when one exists
+- `event` field uses snake_case: `order_created`, `reservation_confirmed`,
+  `catering_order_created`
+
+### Downstream Services — success after external calls
+
+Services that call external APIs (email, WhatsApp) log success after each call.
+
+```python
+logger.info("WhatsApp sent to owner — %d chars", len(body))
+logger.info("Email sent to %s — subject: %s", to, subject)
+```
+
+Rules:
+- Prose only — no `extra={}` needed (no reference number at this layer)
+- Never log the full recipient email in production — partial logging is fine
+  if needed for debugging (see PII rules below)
+
+### Notification Service — failures per channel
+
+Log each channel failure individually with the reference number so you can
+tell exactly which channel failed for which business event.
+
+```python
+logger.error(
+    "[notifications] order customer email failed — reference: %s: %s",
+    reference, e
+)
+```
+
+### Middleware — do not add logging here
+
+Request/response logging is already handled by `RequestLoggingMiddleware`.
+Do not add logger calls inside middleware — it runs on every request and
+any mistake here affects all routes.
+
+---
+
+## Log Structure Reference
+
+| Field | Source | Present in |
+|---|---|---|
+| `asctime` | Automatic | All lines |
+| `levelname` | Automatic | All lines |
+| `name` | `getLogger(__name__)` | All lines |
+| `request_id` | `RequestIdFilter` | All lines |
+| `message` | Your log call | All lines |
+| `event` | `extra={"event": ...}` | Business events only |
+| `reference` | `extra={"reference": ...}` | Business events only |
+
+**Good log message — router error:**
+```
+[orders] failed to create order
+```
+
+**Good log message — business event:**
+```
+[orders] order created — reference: AKR-20260414-0012
+extra: {"event": "order_created", "reference": "AKR-20260414-0012"}
+```
+
+**Bad log message:**
+```
+unexpected error        ← no router prefix, no operation name
+error occurred: {e}     ← use logger.exception(), not logger.error() with {e}
+order placed            ← no reference number, no extra fields
+```
+
+---
+
+## What Never to Log
+
+- Query parameters — can contain customer PII (`?email=...`, `?name=...`)
+- Request bodies — contain customer names, emails, phone numbers, order details
+- Full recipient email addresses in infrastructure or middleware logs
+- Stack dumps in the message string — use `logger.exception()` which handles this
+
+---
+
+## Output Format
+
+| Environment | Format | Why |
+|---|---|---|
+| Production (`IS_PRODUCTION=true`) | JSON — parsed by Render log viewer | Structured queries, Render log search |
+| Local dev | Human-readable | Easy to read in terminal |
+
+Controlled by `setup_logging()` in `core/logging.py` — no code changes needed.
+
+---
+
+## Sentry (coming)
+
+Sentry will be added as part of task 3.7 / 3.14 / 3.16.9. It will automatically
+capture every `logger.exception()` call with full stack trace and request context.
+No changes to existing log calls will be needed — Sentry integrates with the
+standard Python `logging` module via a log handler.

--- a/graphql-gateway/scripts/validate-config.js
+++ b/graphql-gateway/scripts/validate-config.js
@@ -1,3 +1,21 @@
-export default [
+// mappings: GraphQL response types that correspond to a named schema in backend/openapi.json.
+// The validator checks that every field in the GraphQL type also exists in the OpenAPI schema,
+// catching the case where the backend removes or renames a field that React is still requesting.
+// Add an entry here whenever you add a new GraphQL response type that has an OpenAPI counterpart.
+export const mappings = [
   { graphqlType: "MenuItem", openapiSchema: "MenuItem" },
+  { graphqlType: "DeliveryValidateResponse", openapiSchema: "DeliveryValidateResponse" },
+];
+
+// excluded: response types intentionally omitted from field validation.
+// These have no direct OpenAPI counterpart — either they are gateway-only wrappers, or the
+// backend has not yet documented the response schema in openapi.json.
+// The self-check in validate-schema.js warns for any object type not in either list, so every
+// type must appear in one of these two arrays. That warning is the mechanism that prevents a
+// new type from being silently forgotten.
+export const excluded = [
+  "MenuCategory",        // nested inside MenuResponse; not a standalone backend model
+  "MenuResponse",        // gateway wrapper grouping categories — no single OpenAPI schema for this
+  "OrderResponse",       // /api/orders returns empty schema in openapi.json — move to mappings once backend documents it
+  "ReservationResponse", // same gap as OrderResponse
 ];

--- a/graphql-gateway/scripts/validate-schema.js
+++ b/graphql-gateway/scripts/validate-schema.js
@@ -1,6 +1,6 @@
 import { readFileSync } from "fs";
-import { buildSchema } from "graphql";
-import mappings from "./validate-config.js";
+import { buildSchema, isObjectType } from "graphql";
+import { mappings, excluded } from "./validate-config.js";
 
 const SCHEMA_PATH = process.env.SCHEMA_PATH ?? "graphql-gateway/schemas/menu.graphql";
 const OPENAPI_PATH = process.env.OPENAPI_PATH ?? "backend/openapi.json";
@@ -11,8 +11,15 @@ const openapi = JSON.parse(readFileSync(OPENAPI_PATH, "utf8"));
 const schema = buildSchema(schemaText);
 let failed = false;
 
+// Field-level validation: for each mapped type, every GraphQL field must exist in the
+// corresponding OpenAPI schema. This catches the case where the backend removes or renames
+// a field after the GraphQL schema was written.
+// Types not present in this schema file are silently skipped — they are validated when
+// CI runs this script against their own schema file.
 for (const { graphqlType, openapiSchema } of mappings) {
   const gqlType = schema.getType(graphqlType);
+  if (!gqlType) continue;
+
   const graphqlFields = Object.keys(gqlType.getFields());
   const openapiFields = Object.keys(openapi.components.schemas[openapiSchema].properties);
 
@@ -25,6 +32,34 @@ for (const { graphqlType, openapiSchema } of mappings) {
   } else {
     console.log(`${graphqlType} — all fields match openapi.json.`);
   }
+}
+
+// Self-check: warn for any object type in this schema that is not listed in either mappings
+// or excluded. This is the mechanism that catches a new type being added to the schema without
+// updating validate-config.js — the mistake that caused us to miss OrderResponse and
+// ReservationResponse after the orders/reservations migration.
+// Emits a warning (not a failure) because a type may legitimately have no OpenAPI counterpart;
+// the developer must decide which list it belongs in.
+const ROOT_TYPES = new Set(["Query", "Mutation", "Subscription"]);
+const MAPPED = new Set(mappings.map(m => m.graphqlType));
+const EXCLUDED = new Set(excluded);
+
+const unmapped = Object.entries(schema.getTypeMap())
+  .filter(([name, type]) =>
+    !name.startsWith("__") &&
+    !ROOT_TYPES.has(name) &&
+    isObjectType(type) &&
+    !MAPPED.has(name) &&
+    !EXCLUDED.has(name)
+  )
+  .map(([name]) => name);
+
+// Fail so CI blocks the PR — a warning is ignorable, a failure is not.
+// Start strict; relax later based on real blocking experience.
+if (unmapped.length > 0) {
+  console.error(`\nValidation failed: response types in ${SCHEMA_PATH} not listed in validate-config.js:`);
+  unmapped.forEach(t => console.error(`  - ${t}  →  add to mappings (has OpenAPI schema) or excluded (does not)`));
+  failed = true;
 }
 
 if (failed) process.exit(1);


### PR DESCRIPTION
Adds validate-schema.js (field-level + self-check), updates validate-config.js with DeliveryValidateResponse and excluded list, wires CI to loop over all schemas and run graphql-inspector diff against main. Adds VS Code debug launch config.