### PR TITLE
docs: update execution plan and add Observation Layer to agent workflow

### DIFF
--- a/docs/engineering-practices/ai-agent-workflow.md
+++ b/docs/engineering-practices/ai-agent-workflow.md
@@ -1,7 +1,7 @@
 # AI Agent Workflow — Development to Production
 
 **Scope:** All engineers and AI agents working in this repository.
-**Last updated:** 2026-04-24
+**Last updated:** 2026-04-27
 
 > **Note on CI tooling:** The inner loop diagram shows frontend tools (Husky, ESLint, TypeScript, Vitest). Backend uses pre-commit framework, Black, Flake8, and pytest. The phases and principles are identical — only the tool names differ. When the repo splits, each team copies this file and updates the tool names for their stack.
 
@@ -53,11 +53,11 @@ sequenceDiagram
 
     rect rgb(220, 255, 220)
         note over CI: Phase 3 — CI Checks
-        CI->>CI: Build check — compile and bundle
-        CI->>CI: Lint check — whole project
-        CI->>CI: Test suite
-        CI->>CI: Future — Schema validator
-        CI->>CI: Future — graphql-inspector
+        CI->>CI: TypeScript compile — zero type errors
+        CI->>CI: ESLint — zero warnings
+        CI->>CI: Frontend build
+        CI->>CI: Schema validator — every GraphQL field vs openapi.json
+        CI->>CI: graphql-inspector — breaking schema changes vs main
         alt Any check fails
             CI-->>GH: Status FAILED
             GH-->>Human: Red cross on PR — merge button locked
@@ -90,17 +90,65 @@ sequenceDiagram
     end
 
     rect rgb(220, 245, 255)
-        note over Prod, Monitor: Phase 6 — Production Monitoring
-        Monitor->>Prod: Canary tests every 50 min
-        alt Canary fails
-            Monitor->>GH: Auto-opens issue — canary-failure label
+        note over Prod, Monitor: Phase 6 — Observation Layer (always on — see diagram below)
+        Prod-->>Monitor: Frontend JS errors → Sentry via logger.ts
+        Prod-->>Monitor: Gateway errors → Sentry via @sentry/node
+        Prod-->>Monitor: Backend errors → Render logs via Python structured logging
+        Monitor->>Prod: Canary tests every 50 min (GitHub Actions)
+        Monitor->>Prod: UptimeRobot HTTP check every 5 min
+        alt Alert condition
+            Monitor->>GH: Auto-opens canary-failure issue
             GH-->>Human: Email notification
-        else Canary recovers
+        else Recovered
             Monitor->>GH: Auto-closes canary-failure issue
         end
-        Prod-->>Monitor: Runtime errors captured by Sentry
+        Monitor-->>Dev: Sentry dashboard — error notifications
     end
 ```
+
+---
+
+## Observation Layer
+
+Three independent logging stacks run continuously in production — one per tier. They are always on, independent of deployment events, and feed directly into the outer loop signal sources.
+
+```mermaid
+flowchart TD
+    subgraph Prod["Production — Three Tiers"]
+        FE["Frontend\nVercel CDN\n@sentry/react"]
+        GW["GraphQL Gateway\nVercel Node.js\n@sentry/node"]
+        BE["Backend\nRender FastAPI\nPython structured logging"]
+    end
+
+    subgraph Obs["Observation Layer (always on)"]
+        SE["Sentry\nFrontend and Gateway errors\nStack traces · ARIA breadcrumbs\nbeforeBreadcrumb hook normalises selectors"]
+        RL["Render Logs\nJSON per request in production\nrequest_id · event · reference\nNever logs PII"]
+        CA["Canary Tests\nGitHub Actions every 50 min\nUptimeRobot every 5 min\nHealth · menu · delivery endpoints"]
+        AI["AI Monitor Agent\ncron-job.org → /api/internal/monitor\nRule-based threshold checks\nTwo consecutive 6h windows"]
+    end
+
+    FE -- "logger.ts → Sentry.captureException()\nOnly unknown errors — expected\nbusiness errors handled in UI" --> SE
+    GW -- "Sentry.init() before Apollo Server\nCaptures unhandled resolver errors" --> SE
+    BE -- "logger.exception() in routers\nlogger.info() in services\nOn every business event" --> RL
+
+    RL --> AI
+    CA -->|"health · menu · delivery"| FE & GW & BE
+
+    SE -->|"new or spiked error"| Alert["Developer notified\nSentry dashboard"]
+    CA -->|"endpoint failure"| Issue["GitHub Issue auto-opened\ncanary-failure label + owner email"]
+    AI -->|"threshold breached"| Issue
+    AI -->|"metrics recover"| Close["GitHub Issue auto-closed"]
+```
+
+### What each stack captures
+
+| Stack | Tool | Captures | Does not capture |
+|---|---|---|---|
+| Frontend | `@sentry/react` + `logger.ts` | Unhandled JS exceptions, explicit `logger.error()` calls | Expected business errors (ZIP not covered, sold out) — those are handled in UI |
+| Gateway | `@sentry/node` | Unhandled resolver errors, uncaught gateway exceptions | GraphQL user errors (those are returned in the `errors` field, not thrown) |
+| Backend | Python `logging` + Render | Every router failure (`logger.exception`), every business event created (`logger.info`) | Frontend and gateway events — each tier owns its own stack |
+| Canary | GitHub Actions + UptimeRobot | Endpoint availability and correctness on a schedule | Silent data corruption, logic errors that still return 200 |
+| AI Monitor | cron-job.org agent | Error rate trends, latency spikes, notification failure patterns | Anything requiring human design judgement |
 
 ---
 
@@ -159,8 +207,8 @@ flowchart TD
 | CI — build | Compile errors, broken imports, missing modules | Runtime logic errors |
 | CI — lint | Lint violations across the whole project | Issues outside lint rule coverage |
 | CI — tests | Unit test regressions | Integration failures, end-to-end behaviour |
-| CI — schema validator *(future)* | GraphQL fields missing from backend openapi.json | Runtime data shape mismatches |
-| CI — graphql-inspector *(future)* | Breaking GraphQL schema changes vs main | Non-breaking drift |
+| CI — schema validator | GraphQL fields missing from backend openapi.json | Runtime data shape mismatches |
+| CI — graphql-inspector | Breaking GraphQL schema changes vs main | Non-breaking drift |
 | Human review | Intent, logic, and design problems | Anything automated checks already cover |
 | Canary + Sentry | Production runtime failures | Pre-production issues |
 | **Agent ops loop** | **Error trends, recurring bugs, doc drift — patterns CI cannot see** | **Issues requiring human design judgement** |

--- a/execution-plan.md
+++ b/execution-plan.md
@@ -1,6 +1,6 @@
 # Execution Plan — Aap ki Rasoi Backend
 **Status: APPROVED — Signed off by Vikas, 2026-04-06**
-**Last updated: 2026-04-24**
+**Last updated: 2026-04-27**
 **Reference:** See `docs/architecture.md` for full design decisions.
 
 ---
@@ -215,7 +215,7 @@ See **CLAUDE.md** — "Slice Rules" and "Pair Programming Rules" sections.
 | 3.4 | Deploy frontend to Vercel | Connect GitHub repo, vercel.json rewrite to Render URL | ✅ Done 2026-04-13 |
 | 3.5 | End-to-end smoke test | Full order flow on production URLs | ✅ Done 2026-04-13 |
 | 3.6 | Canary monitoring setup | UptimeRobot HTTP check on `/health` every 5 min (unlimited); GitHub Actions runs canary tests every 50 min (~864 min/month, well within free tier); alert to owner email on failure | ✅ Done 2026-04-14 |
-| 3.7 | Sentry setup — frontend | Install `@sentry/browser` in React app; capture page crashes, JS errors, network errors; create `src/lib/logger.ts` utility (`logger.warn` / `logger.error`) so all explicit logging goes to Sentry in production; verify errors appear in Sentry dashboard | ⏳ Pending |
+| 3.7 | Sentry setup — frontend | Install `@sentry/browser` in React app; capture page crashes, JS errors, network errors; create `src/lib/logger.ts` utility (`logger.warn` / `logger.error`) so all explicit logging goes to Sentry in production; verify errors appear in Sentry dashboard | ✅ Done 2026-04-27 |
 | 3.8 | Runbook skeleton | Create `backend/docs/runbook.md` with one entry per monitored metric category; each entry: symptom, likely cause, diagnostic steps, fix; grow incrementally as each monitoring metric is instrumented | ✅ Done 2026-04-14 |
 | 3.9 | Request logging middleware | FastAPI middleware that logs every request (endpoint, method, status code, duration ms) to a `request_logs` DB table; foundation for error rate, latency, throttling, and request count metrics | ✅ Done 2026-04-14 |
 | 3.10 | Notification failure logging | Log Twilio/Resend call results (success/failure, provider, error code) to a `notification_logs` DB table; enables outbound throttling and downstream failure metrics | ✅ Done 2026-04-14 |
@@ -224,7 +224,7 @@ See **CLAUDE.md** — "Slice Rules" and "Pair Programming Rules" sections.
 | 3.13 | AI monitoring agent — Phase 2 (MCP) | MCP server (`backend/mcp_server.py`) with 6 tools: `check_health_endpoint`, `get_render_logs`, `get_recent_commits`, `query_request_logs`, `query_notification_failures`, `check_provider_status`; registered via `.claude/settings.json`; sub-skills updated to call MCP tools instead of manual steps — Render log review now automatic | ✅ Done 2026-04-16 — ✅ Follow-up resolved 2026-04-16: all sub-skills updated to MCP tool calls; config.py fixed to use `Path(__file__).parent.parent / ".env"` so MCP server loads correct env from any working directory; tools verified working end-to-end via Claude CLI (`health` reachable, Render logs returning real data) — ⚠️ Open: MCP server not connecting in VSCode extension (v2.1.112) — extension appears to ignore `mcpServers` stdio config in `settings.json`; workaround is to run `claude --mcp-config .claude/settings.json` from project root in terminal; needs investigation when VSCode extension is updated |
 | 3.14 | Sentry backend SDK | Install `sentry-sdk[fastapi]`; auto-capture unhandled exceptions with request context (URL, method, correlation ID); correlates with frontend Sentry project; zero additional cost on free tier | ⏳ Pending |
 | 3.15 | Two-team ownership setup | Export `openapi.json`, add contract rules to CLAUDE.md files, create `lovable_project/CLAUDE.md` — see Phase 2 — Two-Team Ownership Setup section for full detail | ⏳ Pending |
-| 3.16 | GraphQL gateway layer | Frontend-owned Apollo Server gateway; Menu fully migrated; remaining features (Orders, Catering, Reservations) still on REST — see Phase 2 section for remaining steps | 🔄 In Progress |
+| 3.16 | GraphQL gateway layer | Frontend-owned Apollo Server gateway; Menu, Orders, Reservations migrated; Catering still on REST — see Phase 2 section for remaining steps | 🔄 In Progress |
 | 3.17 | Homepage dynamic content | `Index.tsx` now reads Meal of the Day and Latest Offers from GraphQL (live menu data); static `menuItems` deleted from `src/data/menu.ts` | ✅ Done 2026-04-24 |
 
 ---
@@ -280,7 +280,7 @@ Workflow: `.github/workflows/canary.yml` — runs with `--noconftest` to avoid l
 | DT-6 | Skill: `/design` | ⏳ Pending |
 | DT-7 | Skill: `/spec` | ⏳ Pending |
 | DT-8 | Skill: `/execution-plan` | ⏳ Pending |
-| DT-9 | CI pipeline — GitHub Actions | TypeScript compile + ESLint + frontend build on every push/PR; prerequisite for schema validator and graphql-inspector | ⏳ Pending — **next session** |
+| DT-9 | CI pipeline — GitHub Actions | TypeScript compile + ESLint + frontend build on every push/PR; prerequisite for schema validator and graphql-inspector | ✅ Done 2026-04-24 |
 | DT-10 | Unit + integration tests — menu slice (backend + frontend) | ⏳ Pending |
 
 ---
@@ -297,12 +297,12 @@ Workflow: `.github/workflows/canary.yml` — runs with `--noconftest` to avoid l
 | 3.16.4 — Menu resolvers | `graphql-gateway/resolvers/menu.ts` — extracted from index.ts | ✅ Done 2026-04-24 |
 | 3.16.5 — graphql-codegen | `codegen.ts` at repo root; generates `src/__generated__/menu.ts` | ✅ Done 2026-04-24 |
 | 3.16.6 — Menu component migration | `useMenu` hook, `MenuPage.tsx` + `Index.tsx` on GraphQL; static menuItems deleted; `src/features/menu/` feature folder complete | ✅ Done 2026-04-24 |
-| 3.16.7 — CI schema validator | `graphql-gateway/scripts/validate-schema.js` — checks every GraphQL field against `openapi.json`; wired into GitHub Actions (requires DT-9 first) | ⏳ Pending |
-| 3.16.8 — graphql-inspector in CI | Detects breaking schema changes between commits; wired into GitHub Actions | ⏳ Pending |
-| 3.16.9 — Sentry gateway SDK | Add `@sentry/node` to gateway; done alongside 3.7 + 3.14 Sentry session | ⏳ Pending |
-| 3.16.10 — Orders GraphQL migration | Schema + resolver + `useOrders` hook; migrate `OrderPage.tsx` | ⏳ Pending |
+| 3.16.7 — CI schema validator | `graphql-gateway/scripts/validate-schema.js` — checks every GraphQL field against `openapi.json`; wired into GitHub Actions (requires DT-9 first) | ✅ Done 2026-04-25 |
+| 3.16.8 — graphql-inspector in CI | Detects breaking schema changes between commits; wired into GitHub Actions | ✅ Done 2026-04-25 |
+| 3.16.9 — Sentry gateway SDK | Add `@sentry/node` to gateway; done alongside 3.7 + 3.14 Sentry session | ✅ Done 2026-04-27 |
+| 3.16.10 — Orders GraphQL migration | Schema + resolver + `useOrders` hook; migrate `OrderPage.tsx` | ✅ Done 2026-04-26 |
 | 3.16.11 — Catering GraphQL migration | Schema + resolver + `useCatering` hook; migrate `CateringPage.tsx` | ⏳ Pending |
-| 3.16.12 — Reservations GraphQL migration | Schema + resolver + `useReservations` hook; migrate `ReservationPage.tsx` | ⏳ Pending |
+| 3.16.12 — Reservations GraphQL migration | Schema + resolver + `useReservations` hook; migrate `ReservationPage.tsx` | ✅ Done 2026-04-26 |
 
 ### Feature Folder Migration Convention
 Migrate one feature at a time to `src/features/[feature]/` — only when that feature moves to GraphQL. See `src/docs/feature-migration-guide.md` for steps and rollback plan.


### PR DESCRIPTION
Mark DT-9, 3.16.7, 3.16.8, 3.16.9, 3.16.10, 3.16.12, 3.7 as done. Add Observation Layer diagram showing the three logging stacks (Sentry frontend, Sentry gateway, Python structured logging) and how they feed canary and AI monitor agent. Remove Future labels from CI checks.