### PR TITLE
fix: resolve duplicate Mermaid gitGraph merge IDs in branching-strategy

### DIFF
--- a/docs/engineering-practices/branching-strategy.md
+++ b/docs/engineering-practices/branching-strategy.md
@@ -44,12 +44,12 @@ gitGraph
    commit id: "wire up API call"
    commit id: "add validation"
    checkout main
-   merge feature/catering-form id: "PR merged ✓"
+   merge feature/catering-form id: "PR #1 merged ✓"
    branch fix/cart-rounding
    checkout fix/cart-rounding
    commit id: "fix rounding error"
    checkout main
-   merge fix/cart-rounding id: "PR merged ✓"
+   merge fix/cart-rounding id: "PR #2 merged ✓"
 ```
 
 **Step by step:**


### PR DESCRIPTION
Mermaid requires unique commit IDs within a gitGraph — using "PR merged ✓" twice caused the diagram to fail rendering. Changed to "PR #1 merged ✓" and "PR #2 merged ✓" to make each ID unique.