### PR TITLE
test: introduce deliberate allergens field omission for Sentry exercise

### DIFF
--- a/src/features/menu/hooks/useMenu.ts
+++ b/src/features/menu/hooks/useMenu.ts
@@ -18,7 +18,6 @@ const MENU_QUERY = gql`
           is_available
           catering_available
           catering_price_per_tray
-          allergens
           display_order
         }
       }


### PR DESCRIPTION
Removes allergens from the GraphQL menu query to simulate a production bug where FoodItemModal crashes on render (undefined.map). Used to practice the outer loop agent observation workflow.