### PR TITLE
docs: update agent architecture with monitoring workflows layer

### DIFF
--- a/docs/engineering-practices/agent-architecture.md
+++ b/docs/engineering-practices/agent-architecture.md
@@ -1,7 +1,7 @@
 # Agent Architecture — Aap ki Rasoi
 
 **Status: DRAFT**
-**Last updated: 2026-04-28**
+**Last updated: 2026-04-28 (updated: monitoring workflows layer added)**
 **Workflow context:** See `docs/engineering-practices/ai-agent-workflow.md` — two-loop model (inner/outer), signal sources, and recommended agent behaviour.
 **Implementation plan:** See `docs/engineering-practices/agent-execution-plan.md` — phases, tasks, and validation scenarios.
 
@@ -66,10 +66,61 @@
 
 ---
 
+## Monitoring Workflows
+
+Two scheduled GitHub Actions workflows form the **outer monitoring layer** — they sit outside the agent orchestration stack and serve as the automated entry point for the reactive pipeline. The orchestrator and all agents are invoked only after the monitoring workflow decides an issue warrants investigation.
+
+### Overall Pipeline
+
+```
+GitHub Actions (scheduled cron)
+  ├── sentry-monitor-frontend.yml  — polls frontend Sentry project on a schedule
+  └── sentry-monitor-backend.yml  — polls backend Sentry project on a schedule
+       │
+       ▼  if threshold crossed AND no matching open issue
+  GitHub Issue created  (labels: needs-analysis, source:frontend-sentry OR source:backend-sentry)
+       │
+       ▼  triggers
+  agent-orchestrator.yml  (on: issues: [labeled: needs-analysis])
+       │
+       ▼
+  Orchestrator Agent → specialized agents → Recommendation Agent → comment on issue
+```
+
+### Workflow Responsibilities
+
+| Workflow | Sentry project | Schedule | Output |
+|---|---|---|---|
+| `sentry-monitor-frontend.yml` | Frontend Sentry | Every 30 min (configurable via env var) | GitHub issue with `needs-analysis` + `source:frontend-sentry` labels |
+| `sentry-monitor-backend.yml` | Backend Sentry | Every 30 min (configurable via env var) | GitHub issue with `needs-analysis` + `source:backend-sentry` labels |
+
+### De-duplication Rule
+
+Before creating a new issue, the monitoring workflow must query open GitHub issues for a matching Sentry error fingerprint (Sentry group ID). Two outcomes:
+
+- **No matching open issue** — create a new GitHub issue with the labels above
+- **Matching open issue exists** — comment on the existing issue with the latest error count and timestamp; do not create a new issue
+
+This prevents duplicate issues from accumulating across cron cycles for the same ongoing error.
+
+### Handoff Contract
+
+The `needs-analysis` label is the contract between the monitoring workflow and the orchestrator workflow. The `source:frontend-sentry` or `source:backend-sentry` label tells the orchestrator which Sentry project to query first. Both labels must be present for the orchestrator workflow to trigger.
+
+The issue body written by the monitoring workflow must include:
+- Sentry error fingerprint (group ID — not the raw error message)
+- Error count in the detection window
+- First seen / last seen timestamps
+- Top-line error message — **redacted of all PII before posting**
+- Deep link to the Sentry error group
+
+---
+
 ## Access Matrix
 
-| Agent | Frontend Sentry | Backend Sentry | Render Logs | GitHub (read) | GitHub (write) | Codebase | Email (Resend) |
+| Component | Frontend Sentry | Backend Sentry | Render Logs | GitHub (read) | GitHub (write) | Codebase | Email (Resend) |
 |---|---|---|---|---|---|---|---|
+| **Monitoring Workflows** | ✅ Read (frontend wf only) | ✅ Read (backend wf only) | ❌ | ❌ | ✅ Create issues + comment | ❌ | ❌ |
 | Frontend Sentry Agent | ✅ Read | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Backend Sentry Agent | ❌ | ✅ Read | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Render Logs Agent | ❌ | ❌ | ✅ Read | ❌ | ❌ | ❌ | ❌ |
@@ -84,43 +135,70 @@
 
 | Trigger | Source | Orchestrator Entry Point |
 |---|---|---|
-| Scheduled proactive check | Cron (daily) | Check Sentry for error spikes; check Render for operational anomalies |
-| GitHub issue opened | GitHub webhook or manual invocation | Read issue → extract symptom → investigate |
-| Sentry alert threshold crossed | Sentry alert webhook | Read error group → investigate |
+| Sentry monitoring workflow | GitHub Actions scheduled cron — two separate workflows (frontend and backend) | Monitoring workflow creates GitHub issue with `needs-analysis` + `source:*` labels; orchestrator workflow triggers on label event |
+| GitHub issue labeled `needs-analysis` | Label applied by monitoring workflow or manually | Read issue → extract symptom, source label, Sentry fingerprint → investigate |
 | Manual invocation | `/troubleshoot` skill | User provides symptom or issue number → investigate |
+
+> **Note:** Direct Sentry alert webhooks are not used. Sentry's GitHub integration for issue creation is a paid feature. All automated Sentry monitoring goes through the scheduled GitHub Actions workflows above.
 
 ---
 
 ## Orchestration Flow
 
-### Proactive (scheduled / Sentry alert)
+### Automated Monitoring (Sentry threshold breach)
+
+Phase 1 — Monitoring workflow (GitHub Actions, no Claude involved):
 ```
-Trigger
-  → Orchestrator
-  → Frontend Sentry Agent (JS error spikes, gateway exceptions)
-  → Backend Sentry Agent (Python exception spikes, FastAPI errors)
-  → [if issues found] Render Logs Agent (confirm operational health)
-  → [if issues found] Codebase Agent (trace the affected field/path)
-  → [if issues found] GitHub Agent (check for recent commits touching the affected area)
-  → Recommendation Agent (synthesize → confidence level + root cause + recommended fix)
-  → Orchestrator opens GitHub Issue with full findings
-  → [high confidence] Orchestrator sends email notification via Resend
+sentry-monitor-frontend.yml OR sentry-monitor-backend.yml (scheduled cron)
+  → calls Sentry API — checks error count against configurable threshold
+  → de-duplication check: open issue with matching Sentry fingerprint?
+      → [yes] comment on existing issue with updated count and timestamp — stop
+      → [no] create GitHub issue
+            title: "[Sentry] <top-line error> — <project>"
+            labels: needs-analysis, source:frontend-sentry OR source:backend-sentry
+            body: fingerprint, error count, first/last seen, redacted message, Sentry deep link
+```
+
+Phase 2 — Agent orchestration (triggered by label event):
+```
+agent-orchestrator.yml  (on: issues labeled: needs-analysis)
+  → Orchestrator Agent reads issue — extracts fingerprint, source label, time window
+  → [source:frontend-sentry] Frontend Sentry Agent
+        detailed JS error trace, breadcrumbs, affected release tag
+  → [source:backend-sentry] Backend Sentry Agent
+        detailed Python exception trace, request context, affected release tag
+  → [backend source] Render Logs Agent
+        operational health at error time — startup events, crash events
+  → Codebase Agent
+        trace affected field or endpoint through component → hook → query → resolver → backend
+  → GitHub Agent
+        recent commits touching the affected area; any related open issues
+  → Recommendation Agent
+        root cause statement, confidence level, recommended fix, runbook reference
+  → Orchestrator comments on the GitHub issue with full structured findings
+  → [high confidence] email notification via Resend
   → Human reviews → /approve / /reject / /investigate
   → [approved] Orchestrator executes recommended action
 ```
 
-### Reactive (GitHub issue / manual)
+### Reactive (manual GitHub issue or `/troubleshoot` skill)
 ```
-Trigger (issue number or symptom)
-  → Orchestrator
-  → GitHub Agent (read the issue, extract symptom, check recent related PRs)
-  → [frontend symptom] Frontend Sentry Agent (find matching JS errors in the issue time window)
-  → [backend symptom] Backend Sentry Agent (find matching Python errors in the issue time window)
-  → Render Logs Agent (check operational health at the time of the issue)
-  → Codebase Agent (trace the symptom through the stack)
-  → Recommendation Agent (synthesize → confidence level + root cause + recommended fix)
-  → Orchestrator comments on the GitHub Issue with findings
-  → [high confidence] Orchestrator sends email notification via Resend
+Trigger: issue number OR symptom description from /troubleshoot skill
+  → Orchestrator Agent
+  → GitHub Agent
+        read the issue, extract symptom, check recent related PRs and commits
+  → [frontend symptom] Frontend Sentry Agent
+        matching JS errors in the issue time window
+  → [backend symptom] Backend Sentry Agent
+        matching Python errors in the issue time window
+  → Render Logs Agent
+        operational health at the time of the reported issue
+  → Codebase Agent
+        trace symptom through the full stack
+  → Recommendation Agent
+        root cause statement, confidence level, recommended fix, runbook reference
+  → Orchestrator comments on the GitHub issue with full structured findings
+  → [high confidence] email notification via Resend
   → Human reviews → /approve / /reject / /investigate
   → [approved] Orchestrator executes recommended action
 ```

--- a/execution-plan.md
+++ b/execution-plan.md
@@ -282,6 +282,7 @@ Workflow: `.github/workflows/canary.yml` — runs with `--noconftest` to avoid l
 | DT-8 | Skill: `/execution-plan` | ⏳ Pending |
 | DT-9 | CI pipeline — GitHub Actions | TypeScript compile + ESLint + frontend build on every push/PR; prerequisite for schema validator and graphql-inspector | ✅ Done 2026-04-24 |
 | DT-10 | Unit + integration tests — menu slice (backend + frontend) | ⏳ Pending |
+| DT-11 | **⚠️ Must have — Claude Code token efficiency** | Context window exhaustion is a development blocker. Build a plugin/skill that surfaces live token usage per session, identifies patterns that inflate context (large file reads, over-broad globs, repeated context re-reads), and produces a report of recommended practices (lean context habits, `/compact` timing, session scoping). Goal: no session should hit the token ceiling mid-task. | ⏳ Pending |
 
 ---
 
@@ -322,7 +323,7 @@ Migrate one feature at a time to `src/features/[feature]/` — only when that fe
 
 | Task | Detail | Status |
 |---|---|---|
-| Phase A — Prerequisites | Backend Sentry, release tagging in CI, test scenarios file, runbook coverage, Render API access | ⏳ Pending |
+| Phase A — Prerequisites | Backend Sentry ✅, release tagging in CI ✅, test scenarios file ⏳, runbook coverage ⏳, Render API access ⏳ | 🔄 In Progress |
 | Phase B — Individual Agents | Sentry Agent, Render Logs Agent, GitHub Agent, Codebase Agent, Recommendation Agent | ⏳ Pending |
 | Phase C — Orchestration Layer | Orchestrator, `/troubleshoot` skill, scheduled proactive check, GitHub write authorization | ⏳ Pending |
 | Phase D — Validation | End-to-end validation against all 5 test scenarios + false positive check | ⏳ Pending |

--- a/execution-plan.md
+++ b/execution-plan.md
@@ -330,6 +330,79 @@ Migrate one feature at a time to `src/features/[feature]/` — only when that fe
 
 ---
 
+## Phase 4 — Infrastructure & Reliability
+
+---
+
+### 4.1 — Queue / Notification Integration
+
+> Replace direct Resend/Twilio calls in request handlers with an async queue layer.
+> Currently notifications are fire-and-forget inside the order/reservation save path — a provider failure is logged but there is no retry. A queue decouples notification delivery from the user-facing request, adds retry with backoff, and enables a dead-letter queue for failed messages.
+
+**Current state:** `services/email_service.py` and `services/whatsapp_service.py` called directly from `order_service.py`, `reservation_service.py`, `catering_service.py` — synchronous, no retry.
+
+| # | Task | Description | Status |
+|---|---|---|---|
+| 4.1.1 | Choose queue backend | Evaluate AWS SQS (free tier: 1M requests/month) vs Redis Queue (RQ) vs Celery + Redis — decision based on AWS deployment strategy in 4.2; document choice as ADR | ⏳ Pending |
+| 4.1.2 | Queue service | `services/queue_service.py` — enqueue notification jobs (email and WhatsApp separately); job payload includes type, recipient, reference number, template key — no PII beyond what is needed to render the message | ⏳ Pending |
+| 4.1.3 | Worker | Notification worker that dequeues jobs, calls Resend/Twilio, retries on failure (max 3 attempts, exponential backoff), moves to dead-letter queue after final failure | ⏳ Pending |
+| 4.1.4 | Dead-letter handling | Dead-letter queue consumer logs failure to `notification_logs` table with full retry history; triggers owner alert (email) so no notification is silently lost | ⏳ Pending |
+| 4.1.5 | Wire to slices | Replace direct email/WhatsApp calls in order, reservation, catering services with queue enqueue calls; existing `notification_logs` table records queue entry time + delivery time | ⏳ Pending |
+| 4.1.6 | Automated tests | pytest: job enqueued on order save; worker delivers on dequeue; failed delivery retries up to max; dead-letter entry created after final failure; notification_logs updated correctly | ⏳ Pending |
+| 4.1.7 | Manual verification | Place order → confirm job in queue → confirm delivery → simulate provider failure → confirm retry → confirm dead-letter alert | ⏳ Pending |
+
+---
+
+### 4.2 — AWS DevOps Pipeline (Free Tier)
+
+> Migrate infrastructure from Render + Vercel to AWS. Adds a production-grade CI/CD pipeline with CodePipeline + CodeBuild, backend on AWS compute, static frontend on S3 + CloudFront.
+
+**Current state:** Backend on Render (free tier, cold starts), frontend on Vercel, no AWS CI/CD.
+
+**AWS free tier — what is actually free and for how long:**
+
+| Service | Free allowance | Duration |
+|---|---|---|
+| Lambda | 1M requests + 400K GB-seconds/month | Always free |
+| API Gateway (HTTP API) | 1M requests/month | 12 months only |
+| EC2 t2.micro | 750 hrs/month | 12 months only |
+| Elastic Beanstalk | Free (EC2 underneath is not) | — |
+| S3 | 5 GB storage, 20K GET, 2K PUT/month | 12 months only |
+| CloudFront | 1 TB transfer + 10M requests/month | Always free |
+| CodeBuild | 100 build minutes/month | Always free |
+| CodePipeline | 1 active pipeline/month | Always free |
+| ECR (public) | Unlimited | Always free |
+| ECR (private) | 500 MB/month | 12 months only |
+| Parameter Store (standard) | 10,000 parameters, standard throughput | Always free |
+| **ECS Fargate** | **Not free — ~$10–15/month minimum** | ❌ Not free tier |
+| **Secrets Manager** | **Not free — $0.40/secret/month** | ❌ Not free tier |
+
+**Compute choice — two viable options:**
+
+| Option | Cost | Trade-off |
+|---|---|---|
+| **Lambda + API Gateway** (recommended) | Always free within limits | Requires Mangum adapter to wrap FastAPI; cold starts on first request after idle |
+| **EC2 t2.micro + Elastic Beanstalk** | Free for 12 months, then ~$10/month | No code change needed; warm instance always running; cost starts after year 1 |
+
+**Nice to Have — evaluate at implementation time (paid):**
+- [ ] ECS Fargate — container-native compute, no EC2 management; ~$10–15/month minimum; consider if cold starts or scaling become a problem
+- [ ] Secrets Manager — automatic secret rotation, fine-grained IAM policies; $0.40/secret/month; consider if compliance or rotation requirements arise
+
+| # | Task | Description | Status |
+|---|---|---|---|
+| 4.2.1 | Architecture decision | Choose compute: Lambda + API Gateway (always free, needs Mangum) vs EC2 + Elastic Beanstalk (free 12 months, no code change); document as ADR | ⏳ Pending |
+| 4.2.2 | Backend adapter / Dockerfile | Lambda path: add Mangum, create `handler.py` entry point, package as zip or container image (ECR public — free). EB path: `backend/Dockerfile` — multi-stage build, uvicorn, non-root user | ⏳ Pending |
+| 4.2.3 | ECR setup (public) | Create public ECR repository (always free); push backend image; wire image tag to Git SHA for Sentry release traceability | ⏳ Pending |
+| 4.2.4 | Compute setup | Lambda path: create Lambda function + HTTP API Gateway, configure `/health` check. EB path: create EB environment, t2.micro, configure health check on `/health` | ⏳ Pending |
+| 4.2.5 | Secrets via Parameter Store | Migrate all secrets from Render/Vercel to AWS Parameter Store standard tier (always free); no Secrets Manager — cost not justified on free tier | ⏳ Pending |
+| 4.2.6 | Frontend on S3 + CloudFront | Build React app; upload to S3 bucket; CloudFront distribution; cache invalidation on deploy | ⏳ Pending |
+| 4.2.7 | CodePipeline + CodeBuild | Pipeline: source (GitHub) → build (CodeBuild: tests + build image + push to ECR) → deploy (Lambda update or EB deploy + S3 sync + CloudFront invalidation); stays within 100 free build minutes/month | ⏳ Pending |
+| 4.2.8 | Update Sentry release tagging | Update `sentry-release.yml` to tag releases using CodeBuild build ID / image tag; keeps error → deployment traceability intact | ⏳ Pending |
+| 4.2.9 | Update canary monitoring | Point `API_BASE_URL` in canary workflow at new AWS backend URL; update UptimeRobot to monitor new endpoint | ⏳ Pending |
+| 4.2.10 | Cut-over and smoke test | Run full end-to-end smoke test against AWS URLs; confirm Sentry errors route correctly; confirm notifications deliver; decommission Render + Vercel | ⏳ Pending |
+
+---
+
 ### Nice to Have — Monitoring
 - [ ] Enhance `check_provider_status` to optionally include account-level delivery logs (Resend `GET /emails`, Twilio `GET /Messages.json`) via `include_logs: bool = False` parameter — gives provider's own view of failures, not just our DB's view
 - [ ] Add 4xx alerting thresholds (429, 404, 422, 401/403) as separate tracked metrics in the monitor service — currently these status codes are visible in `query_request_logs` output but do not trigger alerts


### PR DESCRIPTION
- adds Monitoring Workflows section: two scheduled GH Actions workflows (frontend + backend Sentry) as the outer monitoring layer
- documents de-duplication rule and label-based handoff contract
- splits orchestration flow into Phase 1 (GH Actions, no Claude) and Phase 2 (agent orchestration triggered by needs-analysis label)
- updates access matrix and trigger types; removes direct Sentry webhook approach
- adds DT-11 to execution plan: Claude Code token efficiency plugin (must have)
- marks Phase A backend Sentry tasks as in progress (A.1 + A.2 done)