### PR TITLE
docs: update agent architecture and execution plan for Option A

### DIFF
--- a/docs/engineering-practices/agent-architecture.md
+++ b/docs/engineering-practices/agent-architecture.md
@@ -1,9 +1,32 @@
 # Agent Architecture — Aap ki Rasoi
 
 **Status: DRAFT**
-**Last updated: 2026-04-28 (updated: monitoring workflows layer added)**
+**Last updated: 2026-04-29**
 **Workflow context:** See `docs/engineering-practices/ai-agent-workflow.md` — two-loop model (inner/outer), signal sources, and recommended agent behaviour.
 **Implementation plan:** See `docs/engineering-practices/agent-execution-plan.md` — phases, tasks, and validation scenarios.
+
+---
+
+## Index
+
+| Section | Description |
+|---|---|
+| [Principles](#principles) | Core design rules all agents follow |
+| [Agent Catalog](#agent-catalog) | Frontend Sentry, Backend Sentry, Render Logs, GitHub, Codebase, Recommendation, Orchestrator |
+| [Agent Runtime](#agent-runtime) | Packaging decision, directory structure, tool definitions, entry points, model selection |
+| [Finding Schema](#finding-schema) | Common YAML envelope, required fields, schema file location, versioning, agent tag |
+| [Monitoring Workflows](#monitoring-workflows) | Pipeline overview, de-duplication rule, handoff contract |
+| [Access Matrix](#access-matrix) | Which agent can access which system |
+| [Trigger Types](#trigger-types) | How investigations are started |
+| [Orchestration Flow](#orchestration-flow) | Automated (Sentry breach) + reactive (manual / `/troubleshoot`) |
+| [Human in the Loop](#human-in-the-loop) | Notification channels, confidence-gated actions, response options, timeout/escalation |
+| [Runbook Integration](#runbook-integration) | How agents read and grow the runbook |
+| [Compliance Awareness](#compliance-awareness) | When and how to flag PII/PHI |
+| [GitHub Issues as Investigation Record](#github-issues-as-investigation-record) | Issue structure + content rules |
+| [Security — Prompt Injection Resistance](#security--prompt-injection-resistance) | How agents handle adversarial data |
+| [Cost Reference](#cost-reference) | Per-agent, per-investigation, and monthly token cost estimates |
+| [Test Scenarios](#test-scenarios) | Reference to validation scenarios |
+| [Appendix — Design Decisions](#appendix--design-decisions) | Architecture decisions made during design — do not read unless explicitly directed |
 
 ---
 
@@ -55,14 +78,129 @@
 ### Recommendation Agent
 **Responsibility:** Synthesize findings from all other agents into a root cause statement and actionable recommendation.
 **Access:** None — receives only structured findings passed in from the orchestrator
-**Inputs:** structured findings from Sentry Agent, Render Logs Agent, GitHub Agent, Codebase Agent
+**Inputs:** structured findings from Sentry agents, Render Logs Agent, GitHub Agent, Codebase Agent
 **Outputs:** root cause statement, confidence level (high/medium/low), recommended fix, suggested runbook section, escalation flag if confidence is low
 
 ### Orchestrator
-**Responsibility:** Receive triggers, route to the right agents, collect findings, pass to Recommendation Agent, notify the human, and execute approved actions.
+**Responsibility:** Receive triggers, route to the right agents, collect and validate findings, pass to Recommendation Agent, notify the human, and execute approved actions.
 **Access:** Can invoke all agents; can open GitHub Issues and send email (Resend) for notifications; executes write actions only after human approval
-**Inputs:** trigger event (see Trigger Types below); human approval/rejection responses
+**Inputs:** trigger event (see Trigger Types); human approval/rejection responses
 **Outputs:** GitHub Issue with investigation findings; email notification for high-confidence findings; approved actions executed post human sign-off
+
+---
+
+## Agent Runtime
+
+**Decision:** Agents are implemented as a Python package (`agents/`) using the Anthropic SDK with tool use. This is not Claude Code sub-agents — each agent is a focused, stateless agentic loop that runs as a Python script invoked from GitHub Actions or the `/troubleshoot` skill.
+
+### Why This Approach
+
+Each agent's tools are registered Python functions. A tool either exists in the agent's tool list or it does not — there is no prompt-level instruction preventing an action. This is the authorization boundary: an agent cannot call `open_pull_request` until the orchestrator explicitly adds it to the tool list after human approval.
+
+See [Appendix — Design Decisions](#appendix--design-decisions) for the full Option A vs. Option B analysis that led to this decision.
+
+### Directory Structure
+
+```
+agents/
+  schemas/
+    finding-schema.json         ← common finding schema (single source of truth)
+  orchestrator.py               ← receives trigger, routes agents, validates findings, posts to GitHub
+  frontend_sentry_agent.py
+  backend_sentry_agent.py
+  render_logs_agent.py
+  github_agent.py
+  codebase_agent.py
+  recommendation_agent.py
+```
+
+### Tool Definitions
+
+Each agent registers only the tools it needs. Tools are Python functions passed to the Anthropic SDK client. The orchestrator validates each agent's structured finding against `agents/schemas/finding-schema.json` before routing it forward.
+
+If schema validation fails, the orchestrator posts a comment on the GitHub Issue flagging the malformed finding and stops routing. It does not silently pass invalid data downstream.
+
+### Entry Points
+
+| Entry point | Command | Used for |
+|---|---|---|
+| GitHub Actions (automated) | `python agents/orchestrator.py --issue <number>` | Monitoring workflow trigger, label event trigger |
+| `/troubleshoot` skill (manual) | Thin shell wrapper calling the same script | Human-initiated investigation |
+
+Both paths invoke the same `orchestrator.py` — no separate code paths for automated vs. manual. The automated monitoring path runs entirely in GitHub Actions; Claude Code does not need to be running on a developer's laptop.
+
+### Model Selection
+
+Agents do not all run on the same model. The Recommendation Agent and Orchestrator need the strongest reasoning; simpler agents only query an API and return structured output.
+
+| Agent | Recommended model | Rationale |
+|---|---|---|
+| Recommendation Agent | claude-sonnet-4-6 | Complex synthesis across multiple findings |
+| Orchestrator | claude-sonnet-4-6 | Routing decisions and authorization logic |
+| Codebase Agent | claude-sonnet-4-6 | Multi-hop code tracing requires stronger reasoning |
+| Frontend / Backend Sentry Agent | claude-haiku-4-5 | API query + structured output — low complexity |
+| Render Logs Agent | claude-haiku-4-5 | Log filtering + structured output |
+| GitHub Agent | claude-haiku-4-5 | Read issues + commits + structured output |
+
+Models are set via environment variables — never hardcoded. The table above defines the defaults.
+
+---
+
+## Finding Schema
+
+Every agent posts its findings as a GitHub Issue comment. Each comment begins with a YAML block inside a marked HTML comment (the machine-readable contract) followed by a human-readable markdown section.
+
+### Format
+
+```
+<!-- agent-finding -->
+```yaml
+schema_version: "1.0"
+agent: backend-sentry
+status: completed
+source: sentry-backend
+time_window:
+  from: "2026-04-29T10:00:00Z"
+  to: "2026-04-29T10:30:00Z"
+confidence: high
+pii_flag: false
+injection_flag: false
+findings_count: 2
+runbook_match: null
+# agent-specific fields follow
+```
+
+### Human-readable findings in markdown below this line
+
+[Free-form markdown narrative for the on-call engineer]
+```
+
+### Required Fields (Common Envelope)
+
+| Field | Type | Values |
+|---|---|---|
+| `schema_version` | string | Current: `"1.0"` |
+| `agent` | string | `frontend-sentry`, `backend-sentry`, `render-logs`, `github`, `codebase`, `recommendation` |
+| `status` | string | `completed`, `partial`, `failed`, `injection_detected` |
+| `source` | string | Which external system was queried |
+| `time_window.from` / `.to` | ISO 8601 datetime | Coverage window of the investigation |
+| `confidence` | string | `high`, `medium`, `low` |
+| `pii_flag` | boolean | `true` if PII/PHI was encountered in the data |
+| `injection_flag` | boolean | `true` if a prompt injection attempt was detected |
+| `findings_count` | integer | Number of distinct findings returned |
+| `runbook_match` | string or null | Matched runbook pattern name, or `null` |
+
+Agent-specific fields go below the common envelope inside the same YAML block.
+
+### Schema File
+
+The schema lives at `agents/schemas/finding-schema.json` — inside the `agents/` package, not in `docs/`. It ships with the agents and is version-controlled with them. It is the single source of truth: agent prompts reference it, and the orchestrator validates against it using the `jsonschema` Python library.
+
+The `schema_version` field allows the schema to evolve without breaking existing findings. The orchestrator checks `schema_version` before parsing — if it encounters an unknown version it flags the finding and stops rather than misreading fields.
+
+### Agent Tag for Finding Lookup
+
+Each agent comment is marked with `<!-- agent-finding -->` at the top. The orchestrator and any downstream agent locate a specific agent's finding by searching GitHub Issue comments for this tag and matching the `agent` field in the YAML block. This is reliable machine lookup without parsing free-form prose.
 
 ---
 
@@ -83,8 +221,8 @@ GitHub Actions (scheduled cron)
        ▼  triggers
   agent-orchestrator.yml  (on: issues: [labeled: needs-analysis])
        │
-       ▼
-  Orchestrator Agent → specialized agents → Recommendation Agent → comment on issue
+       ▼  runs: python agents/orchestrator.py --issue <number>
+  Orchestrator → specialized agents → Recommendation Agent → comment on issue
 ```
 
 ### Workflow Responsibilities
@@ -162,7 +300,8 @@ sentry-monitor-frontend.yml OR sentry-monitor-backend.yml (scheduled cron)
 Phase 2 — Agent orchestration (triggered by label event):
 ```
 agent-orchestrator.yml  (on: issues labeled: needs-analysis)
-  → Orchestrator Agent reads issue — extracts fingerprint, source label, time window
+  → runs: python agents/orchestrator.py --issue <number>
+  → Orchestrator reads issue — extracts fingerprint, source label, time window
   → [source:frontend-sentry] Frontend Sentry Agent
         detailed JS error trace, breadcrumbs, affected release tag
   → [source:backend-sentry] Backend Sentry Agent
@@ -173,17 +312,19 @@ agent-orchestrator.yml  (on: issues labeled: needs-analysis)
         trace affected field or endpoint through component → hook → query → resolver → backend
   → GitHub Agent
         recent commits touching the affected area; any related open issues
+  → [each finding validated against agents/schemas/finding-schema.json before routing]
   → Recommendation Agent
         root cause statement, confidence level, recommended fix, runbook reference
   → Orchestrator comments on the GitHub issue with full structured findings
   → [high confidence] email notification via Resend
   → Human reviews → /approve / /reject / /investigate
-  → [approved] Orchestrator executes recommended action
+  → [approved] open_pull_request tool added to orchestrator tool list → action executed
 ```
 
 ### Reactive (manual GitHub issue or `/troubleshoot` skill)
 ```
 Trigger: issue number OR symptom description from /troubleshoot skill
+  → runs: python agents/orchestrator.py --issue <number>  (same entry point)
   → Orchestrator Agent
   → GitHub Agent
         read the issue, extract symptom, check recent related PRs and commits
@@ -195,6 +336,7 @@ Trigger: issue number OR symptom description from /troubleshoot skill
         operational health at the time of the reported issue
   → Codebase Agent
         trace symptom through the full stack
+  → [each finding validated against agents/schemas/finding-schema.json before routing]
   → Recommendation Agent
         root cause statement, confidence level, recommended fix, runbook reference
   → Orchestrator comments on the GitHub issue with full structured findings
@@ -347,6 +489,172 @@ External data sources processed by agents — log entries, Sentry payloads, GitH
 
 ---
 
+## Cost Reference
+
+All costs are Claude API token costs only. GitHub, Sentry, and Render API calls have no per-request charge at this project's scale.
+
+### Per-Agent Token Estimate
+
+| Agent | Input tokens | Output tokens | Notes |
+|---|---|---|---|
+| Frontend / Backend Sentry Agent | ~2,000 | ~500 | System prompt + tool defs + pre-filtered Sentry results |
+| Render Logs Agent | ~2,000 | ~400 | Filtered log entries |
+| GitHub Agent | ~2,000 | ~400 | Recent commits + issue body |
+| Codebase Agent | ~2,600 | ~500 | Code snippets + git diff, pre-filtered |
+| Recommendation Agent | ~2,500 | ~600 | All structured findings as input |
+| Orchestrator (all turns) | ~2,000 | ~700 | Routing + schema validation + GitHub comment |
+| **Total per investigation** | **~13,100** | **~3,100** | |
+
+At **Sonnet 4.6** ($3 / 1M input, $15 / 1M output): approximately **$0.09 per investigation**.
+
+### Monthly Estimates (Sonnet 4.6)
+
+| Frequency | Monthly cost |
+|---|---|
+| 20 investigations / month | ~$1.80 |
+| 60 investigations / month | ~$5.40 |
+| 150 investigations / month | ~$13.50 |
+
+### Cost Levers
+
+**Prompt caching** — system prompts that do not change between runs are cached by the Anthropic SDK. Cache hits cost ~90% less on input tokens. At 60 investigations/month, caching alone can bring monthly cost to ~$2–3.
+
+**Mixed model strategy** — simpler agents (Sentry, Render, GitHub) run on Haiku 4.5, which is ~4x cheaper than Sonnet 4.6. Only Recommendation Agent, Orchestrator, and Codebase Agent need Sonnet 4.6. A mixed strategy cuts total cost by ~40–50%.
+
+Models are set via environment variables — see [Agent Runtime](#agent-runtime) for the per-agent model recommendation table.
+
+---
+
 ## Test Scenarios
 
 Agent behaviour is validated against five documented scenarios in `docs/agent-test-scenarios.md`. Each scenario defines the trigger, the expected agent routing, the expected findings per agent, and the expected recommendation. A new agent implementation is not considered complete until it passes all five scenarios.
+
+---
+
+## Appendix — Design Decisions
+
+> This appendix records the architecture decisions made during the design session on 2026-04-29. It is reference material for understanding *why* decisions were made. **Do not read this section during investigations or implementation unless explicitly directed to.**
+
+---
+
+### Decision 1: Finding Format
+
+**Question:** How should agent findings be structured inside a GitHub Issue comment so both the orchestrator and a human on-call engineer can consume them?
+
+**Options considered:**
+- Structured block (YAML/JSON in code fence) followed by human-readable markdown
+- Markdown sections with strict headings only (no structured block)
+
+**Decision:** YAML envelope inside a marked HTML comment at the top of every agent comment, followed by free-form markdown.
+
+**Rationale:** The YAML block is the machine contract — the orchestrator and downstream agents parse it reliably. The markdown section is the human narrative — the on-call engineer reads it without parsing code. Markdown-only sections are fragile for machine parsing and break if an agent rewords a heading. Structured-only comments are hard for humans to scan during a 2am incident.
+
+---
+
+### Decision 2: Schema Enforcement
+
+**Question:** How do we ensure every agent produces a finding that conforms to the common envelope?
+
+**Options considered:**
+- A: JSON Schema file in repo, agents reference it in their system prompts
+- B: Prompt-level contract only — required fields listed in the prompt, no file, no validation
+- C: Schema file + orchestrator validates programmatically (jsonschema library) before routing
+
+**Decision:** Option C — `agents/schemas/finding-schema.json` is the source of truth. Orchestrator validates via `jsonschema` before routing. Malformed findings are flagged on the issue and routing stops.
+
+**Rationale:** Option B relies on the LLM following instructions exactly on every run — silent failures are possible and hard to detect downstream. Option C catches violations explicitly and visibly. The `schema_version` field allows safe schema evolution: the orchestrator checks version before parsing and flags unknown versions rather than silently misreading fields.
+
+---
+
+### Decision 3: Agent Tag for Finding Lookup
+
+**Question:** How does the orchestrator or a downstream agent find a specific agent's finding in a GitHub Issue that may have many comments?
+
+**Decision:** Each agent comment is marked with `<!-- agent-finding -->` at the very top. The orchestrator searches GitHub Issue comments for this HTML comment and matches the `agent` field in the YAML block to locate the right finding.
+
+**Rationale:** GitHub Issue comments are free text. Without a machine-readable marker, finding a specific agent's output requires parsing prose — fragile and error-prone. The HTML comment is invisible to human readers and provides a reliable anchor for programmatic lookup without adding visual noise.
+
+---
+
+### Decision 4: Schema File Location
+
+**Question:** Where should `finding-schema.json` live in the repository?
+
+**Options considered:**
+- `docs/agents/finding-schema.json` — alongside documentation
+- `agents/schemas/finding-schema.json` — inside the agent package
+
+**Decision:** `agents/schemas/finding-schema.json` — inside the `agents/` package.
+
+**Rationale:** Docs are reference material — they do not travel with the runtime. The schema must live in the same package boundary as the agents that read and write it. Whatever ships to the execution environment (GitHub Actions runner) must include the schema. `docs/` is not a runtime artifact; `agents/` is.
+
+---
+
+### Decision 5: Agent Runtime — Option A vs. Option B
+
+**Question:** How should agents be packaged and deployed? Two options were evaluated in full.
+
+**Option A — Python package (`agents/`) using Anthropic SDK**
+- Each agent is a focused agentic loop with registered Python tool functions
+- Tools are Python functions — a tool either exists in the list or it does not
+- Authorization boundary: the orchestrator adds `open_pull_request` to the tool list only after human approval; before that, the function does not exist
+- Entry points: `python agents/orchestrator.py --issue <number>` from both GitHub Actions and `/troubleshoot` skill
+- Schema validation: `jsonschema.validate()` before routing — one function call
+- Testable: tools can be mocked in pytest, agent decisions can be asserted
+
+**Option B — Claude Code sub-agents (`.claude/agents/`)**
+- Each agent is a Claude Code sub-agent spawned via the Agent tool
+- GitHub Actions invokes Claude Code CLI on the runner
+- Built-in tools (Read, Grep, Bash, MCP servers) available without writing tool definitions
+- Authorization boundary: prompt instructions — "do not open a PR until human approves"
+- Claude Code session overhead: system prompt ~4,000 tokens per sub-agent session; unfiltered tool outputs
+- Harder to unit test — testing an LLM session loop, not a function
+- Schema validation must happen inside the prompt or as a post-processing step
+
+**Concrete example — reservation failure incident:**
+
+In Option A, the orchestrator's tool list before human approval is:
+```python
+tools = [invoke_agent(...), post_github_comment(...), send_email(...)]
+# open_pull_request is NOT registered — the function does not exist yet
+```
+After `/approve`, the orchestrator adds it: `tools.append(open_pull_request(...))`. Physical impossibility until that point.
+
+In Option B, Claude always has access to `Bash`. `gh pr create` can be run at any point. The only gate is the prompt instruction "wait for approval." If Claude misreads a casual "looks good" comment as approval, it may act. The capability is always present; only language prevents it.
+
+**Cost comparison:**
+
+| | Input tokens | Output tokens | Cost at Sonnet 4.6 |
+|---|---|---|---|
+| Option A | ~13,100 | ~3,100 | ~$0.09 / investigation |
+| Option B | ~33,000 | ~5,500 | ~$0.18 / investigation |
+
+Option B burns ~2–3x more tokens due to Claude Code session overhead (system prompt repeated per sub-agent session, unfiltered tool outputs passed raw into context).
+
+At 60 investigations/month: Option A ~$5.40, Option B ~$10.80. With prompt caching and mixed model strategy, Option A can reach ~$2–3/month.
+
+**Decision:** Option A.
+
+**Rationale:** The key requirement is that agents will eventually take real production actions. For write actions, a hard authorization boundary — the tool does not exist until the orchestrator registers it post-approval — is safer than a prompt instruction. Option A also makes schema validation a Python function call and allows unit testing of individual agent decisions. The cost difference is secondary but consistent with the same reasoning: Option A's focused, stateless calls give more control over what enters the context window.
+
+---
+
+### Decision 6: No Developer Laptop Required for Automated Monitoring
+
+**Question:** Does Claude Code need to be running on a developer's laptop for the automated monitoring path to work?
+
+**Decision:** No. The automated path (cron → Sentry poll → GitHub Issue → orchestrator) runs entirely in GitHub Actions. `python agents/orchestrator.py` is invoked by the Actions runner. The `/troubleshoot` skill is the manual path and calls the same entry point. No always-on process is needed on any developer machine.
+
+---
+
+### Decision 7: External API Costs
+
+**Question:** Do Sentry, Render, and GitHub API calls incur per-request charges?
+
+**Decision:** No meaningful cost at this project's scale.
+
+- **GitHub API:** Free up to 5,000 requests/hour for authenticated requests. Investigation frequency will never approach this.
+- **Sentry API:** No per-call charge. Cost is determined by the Sentry plan (data retention, event volume) — not API call frequency. 1,440 monitoring calls/day (30-min polling) is within any plan's limits.
+- **Render API:** No per-request charge. Included with the existing Render service subscription.
+
+The only variable cost is Claude API token consumption.

--- a/docs/engineering-practices/agent-execution-plan.md
+++ b/docs/engineering-practices/agent-execution-plan.md
@@ -1,18 +1,19 @@
 # Agent Implementation Execution Plan — Aap ki Rasoi
 
 **Status: DRAFT**
-**Last updated: 2026-04-28**
-**Reference:** See `docs/engineering-practices/agent-architecture.md` for design decisions and access matrix.
+**Last updated: 2026-04-29**
+**Reference:** See `docs/engineering-practices/agent-architecture.md` for design decisions, access matrix, and finding schema.
 **Master plan reference:** See `execution-plan.md` — Phase 3, Agentic Workflows.
 
 ---
 
 ## Guiding Principles
 
-- Build one agent at a time, validate it in isolation before wiring to the orchestrator.
+- Build one phase at a time; validate it fully before moving to the next.
 - Test scenarios (`docs/agent-test-scenarios.md`) are the acceptance criteria — an agent is not done until it passes its relevant scenarios.
 - Runbook must be updated before each agent is built — agents read the runbook, not the other way around.
 - No agent writes to external systems until the orchestration layer is complete and authorization logic is in place.
+- Agents are Python modules in the `agents/` package using the Anthropic SDK. No Claude Code sub-agents.
 
 ---
 
@@ -24,65 +25,106 @@
 |---|---|---|---|
 | A.1 | Backend Sentry | Install `sentry-sdk[fastapi]` on backend; wire to FastAPI; tag releases with commit SHA so errors map to deployments | ✅ Done |
 | A.2 | Sentry release tagging in CI | Separate `sentry-release.yml` workflow fires on push to main; tags release with Git SHA via `getsentry/action-release@v1` | ✅ Done |
-| A.3 | Test scenarios file | Write `docs/agent-test-scenarios.md` — 5 real bugs introduced one at a time to production; each scenario defines trigger, expected agent routing, expected findings, expected recommendation | ⏳ Pending |
-| A.4 | Runbook coverage | Create `docs/runbooks/troubleshooting.md` — cover all 5 test scenarios with named pattern, investigation steps, and expected findings | ⏳ Pending |
-| A.5 | Render logs access | Confirm Render API key is available as env variable; document which log endpoints the Render Logs Agent will use | ⏳ Pending |
-| A.6 | Sequence diagram | Add sequence diagram to agent architecture doc showing agent transitive dependencies and Sentry release → error correlation flow | ⏳ Pending (after all agents designed) |
+| A.3 | Frontend Sentry | Wire the React frontend to the frontend Sentry project; confirm JS errors and breadcrumbs appear in a separate Sentry project from the backend | ⏳ Pending |
+| A.4 | Test scenarios file | Write `docs/agent-test-scenarios.md` — 5 real bugs introduced one at a time to production; each scenario defines trigger, expected agent routing, expected findings per agent, expected recommendation | ⏳ Pending |
+| A.5 | Runbook coverage | Create `docs/runbooks/troubleshooting.md` — cover all 5 test scenarios with named pattern, investigation steps, and expected findings | ⏳ Pending |
+| A.6 | Render logs access | Confirm Render API key is available as env variable; document which log endpoints the Render Logs Agent will call | ⏳ Pending |
+| A.7 | Sequence diagram | Add sequence diagram to agent architecture doc showing agent transitive dependencies and Sentry release → error correlation flow | ⏳ Pending (after all agents designed) |
 
 ---
 
-## Phase B — Individual Agents
+## Phase B — Agent Package Foundation
 
-> Build and validate each agent in isolation against its relevant test scenarios. No orchestrator yet.
+> Establish the `agents/` Python package and shared infrastructure before any individual agent is built. Every subsequent phase depends on this.
 
 | # | Task | Description | Status |
 |---|---|---|---|
-| B.1 | Sentry Agent | Claude Code agent with Sentry MCP; reads error list, trends, stack traces; returns structured findings; validate against Scenario 1 (reservation failures) and Scenario 3 (allergens) | ⏳ Pending |
-| B.2 | Render Logs Agent | Claude Code agent with Render API access; reads runtime and startup logs; returns structured log entries; validate against Scenario 2 (cold start) | ⏳ Pending |
-| B.3 | GitHub Agent | Claude Code agent with GitHub MCP (read-only); reads issues and recent commits; validate against Scenario 3 (allergens issue) and Scenario 4 (wrong total issue) | ⏳ Pending |
-| B.4 | Codebase Agent | Claude Code agent with filesystem read (scoped paths); traces field/symbol through stack; reads runbook; validate against all 5 scenarios | ⏳ Pending |
-| B.5 | Recommendation Agent | Synthesizes structured findings from all agents; produces root cause, confidence level, recommendation, and runbook reference; no external access; validate against all 5 scenarios | ⏳ Pending |
+| B.1 | `agents/` package setup | Create `agents/` directory at repo root; add `requirements.txt` (or `pyproject.toml`) with `anthropic`, `jsonschema`, `PyGithub`, `requests`; confirm package imports cleanly in CI | ⏳ Pending |
+| B.2 | Finding schema file | Create `agents/schemas/finding-schema.json` — defines the common YAML envelope (schema_version, agent, status, source, time_window, confidence, pii_flag, injection_flag, findings_count, runbook_match); see architecture doc Finding Schema section for full field definitions | ⏳ Pending |
+| B.3 | Schema validator utility | Write `agents/validator.py` — single function `validate_finding(yaml_str)` that parses the YAML block from an agent comment and validates it against `finding-schema.json` using `jsonschema`; raise a descriptive error on failure | ⏳ Pending |
+| B.4 | Model config | Add `agents/config.py` — reads per-agent model names from environment variables with defaults (Sonnet 4.6 for Orchestrator, Recommendation, Codebase; Haiku 4.5 for Sentry, Render, GitHub agents); never hardcode model IDs | ⏳ Pending |
 
 ---
 
-## Phase C — Orchestration Layer
+## Phase C — Monitoring Workflows
 
-> Wire agents together under the orchestrator. Add trigger handling and routing logic.
+> Build the outer monitoring layer — two GitHub Actions cron workflows that poll Sentry and create GitHub Issues. No Claude or agent code is involved in this phase. The orchestrator is triggered only after these workflows create an issue.
 
 | # | Task | Description | Status |
 |---|---|---|---|
-| C.1 | Orchestrator design | Document routing logic for each trigger type (proactive, GitHub issue, Sentry alert, manual) — which agents are invoked, in what order, and under what conditions | ⏳ Pending |
-| C.2 | Orchestrator implementation | Implement orchestrator as a Claude Code agent that invokes specialized agents via the Agent tool; handles all four trigger types | ⏳ Pending |
-| C.3 | `/troubleshoot` skill | Expose manual trigger as a Claude Code skill; accepts symptom description or GitHub issue number; invokes orchestrator | ⏳ Pending |
-| C.4 | Scheduled proactive check | Wire cron trigger (daily) to orchestrator proactive flow; output goes to a designated channel or GitHub discussion | ⏳ Pending |
-| C.5 | GitHub write authorization | Implement authorization logic in orchestrator: only post GitHub issue comment if Recommendation Agent confidence is high; human review required for low/medium confidence | ⏳ Pending |
+| C.1 | `sentry-monitor-backend.yml` | Scheduled workflow (every 30 min, configurable via env var); calls Sentry backend project API; checks error count against configurable threshold; de-duplication check (query open issues for matching Sentry group ID); if no match → create GitHub issue with labels `needs-analysis` + `source:backend-sentry`; if match → comment on existing issue with updated count and timestamp | ⏳ Pending |
+| C.2 | `sentry-monitor-frontend.yml` | Same as C.1 for the frontend Sentry project; creates issues with `needs-analysis` + `source:frontend-sentry` labels | ⏳ Pending |
+| C.3 | `agent-orchestrator.yml` | Triggered `on: issues: [labeled: needs-analysis]`; requires both `needs-analysis` and a `source:*` label to be present; runs `python agents/orchestrator.py --issue ${{ github.event.issue.number }}`; passes `ANTHROPIC_API_KEY`, Sentry tokens, Render API key, GitHub token as secrets | ⏳ Pending |
+| C.4 | Issue body contract | Define and document the exact issue body template the monitoring workflows must write: Sentry group ID (fingerprint), error count, first/last seen timestamps, top-line error message (PII-redacted), Sentry deep link | ⏳ Pending |
 
 ---
 
-## Phase D — Validation
+## Phase D — Individual Agents
 
-> Run the complete agent stack against all five test scenarios end-to-end.
+> Build and validate each agent in isolation against its relevant test scenarios. No orchestrator yet — each agent is called directly in tests.
 
 | # | Task | Description | Status |
 |---|---|---|---|
-| D.1 | Scenario 1 — Reservation failures (proactive) | Trigger: scheduled check; agent detects spiking validation errors; traces to date limit rule; recommends fix | ⏳ Pending |
-| D.2 | Scenario 2 — Render cold start (infrastructure) | Trigger: scheduled check; agent correlates Sentry 503s with Render startup log; rules out code bug; recommends keep-alive or tier upgrade | ⏳ Pending |
-| D.3 | Scenario 3 — Missing allergens (GitHub issue) | Trigger: GitHub issue opened; agent traces null field from frontend → query → schema → resolver → backend; recommends adding field back to query | ⏳ Pending |
-| D.4 | Scenario 4 — Wrong order total (GitHub issue) | Trigger: GitHub issue opened; agent traces total → mutation input → menu query → seed data; identifies price entry error | ⏳ Pending |
-| D.5 | Scenario 5 — Schema drift (proactive) | Trigger: Sentry alert; agent detects undefined field in order confirmation; traces to resolver/schema gap; recommends running validate-schema.js | ⏳ Pending |
-| D.6 | False positive check | Run proactive check against a clean system with no active issues; confirm agent does not raise spurious alerts | ⏳ Pending |
+| D.1 | Frontend Sentry Agent | `agents/frontend_sentry_agent.py` — Anthropic SDK agentic loop; tools: `query_sentry_errors`, `get_stack_trace`, `get_affected_releases` (frontend project only); returns YAML finding conforming to `finding-schema.json`; validate against Scenario 1 and any frontend-triggered scenario | ⏳ Pending |
+| D.2 | Backend Sentry Agent | `agents/backend_sentry_agent.py` — same structure as D.1 but scoped to backend Sentry project; adds `endpoint` and `status_code` to agent-specific fields; validate against Scenario 1 (reservation failures) and Scenario 3 (allergens) | ⏳ Pending |
+| D.3 | Render Logs Agent | `agents/render_logs_agent.py` — tools: `get_service_logs`, `get_deployment_events`; returns structured log entries and startup/crash events; validate against Scenario 2 (cold start) | ⏳ Pending |
+| D.4 | GitHub Agent | `agents/github_agent.py` — tools: `get_issue`, `get_recent_commits`, `get_pr_history` (read-only); validate against Scenario 3 (allergens issue) and Scenario 4 (wrong total) | ⏳ Pending |
+| D.5 | Codebase Agent | `agents/codebase_agent.py` — tools: `read_file`, `grep_symbol`, `git_diff` (filesystem read-only, scoped to `src/`, `graphql-gateway/`, `backend/`, `docs/`); traces field/symbol through full stack; reads runbook; validate against all 5 scenarios | ⏳ Pending |
+| D.6 | Recommendation Agent | `agents/recommendation_agent.py` — no external tool access; receives structured findings from orchestrator as input; produces root cause statement, confidence level (high/medium/low), recommended fix, runbook reference, and escalation flag; validate against all 5 scenarios | ⏳ Pending |
+
+---
+
+## Phase E — Orchestration Layer
+
+> Wire agents together under `orchestrator.py`. Add trigger handling, schema validation, routing logic, and authorization gating.
+
+| # | Task | Description | Status |
+|---|---|---|---|
+| E.1 | Orchestrator design | Document routing logic for each of the three trigger types (monitoring workflow label event, manual GitHub issue, `/troubleshoot` skill) — which agents are invoked, in what order, under what conditions; confirm no direct Sentry webhook triggers (not used — paid feature) | ⏳ Pending |
+| E.2 | Orchestrator implementation | `agents/orchestrator.py --issue <number>` — reads issue body and labels; routes to the correct Sentry agent based on `source:*` label; invokes Render Logs, Codebase, GitHub agents; validates each finding via `agents/validator.py` before routing (malformed finding → flag on issue, stop); passes validated findings to Recommendation Agent | ⏳ Pending |
+| E.3 | `/troubleshoot` skill | Claude Code skill in `.claude/skills/`; accepts symptom description or GitHub issue number; shell wrapper that calls `python agents/orchestrator.py --issue <number>`; same entry point as automated path | ⏳ Pending |
+| E.4 | GitHub write authorization | Implement tool-list gating in orchestrator: `post_github_comment` and `send_email` are always in the tool list; `open_pull_request` and other write tools are added to the tool list only after human comments `/approve` on the issue — before that the function does not exist in the agent's tool list; compliance flag (`pii_flag: true` in any finding) blocks `/approve` path until human comments `/compliance-acknowledged` | ⏳ Pending |
+| E.5 | Confidence-gated notifications | Orchestrator reads `confidence` from Recommendation Agent finding; high → post GitHub comment + send Resend email; medium → post GitHub comment only; low → post GitHub comment only with "investigation inconclusive" framing | ⏳ Pending |
+| E.6 | Timeout and escalation | Orchestrator checks for human response after 24 hours on high-confidence findings → send reminder email; after 48 hours → add `escalation-needed` label; never act autonomously on timeout — only re-notify | ⏳ Pending |
+
+---
+
+## Phase F — Validation
+
+> Run the complete agent stack end-to-end against all five test scenarios.
+
+| # | Task | Description | Status |
+|---|---|---|---|
+| F.1 | Scenario 1 — Reservation failures | Trigger: monitoring workflow creates issue; backend Sentry agent detects spiking validation errors; codebase agent traces to date limit rule; recommendation agent recommends fix | ⏳ Pending |
+| F.2 | Scenario 2 — Render cold start | Trigger: monitoring workflow creates issue; Render logs agent correlates Sentry 503s with startup log; codebase agent rules out code bug; recommendation agent recommends keep-alive or tier upgrade | ⏳ Pending |
+| F.3 | Scenario 3 — Missing allergens | Trigger: GitHub issue opened manually (or via `/troubleshoot`); codebase agent traces null field from frontend → query → schema → resolver → backend; recommendation agent recommends adding field back to query | ⏳ Pending |
+| F.4 | Scenario 4 — Wrong order total | Trigger: GitHub issue opened; codebase agent traces total → mutation input → menu query → seed data; GitHub agent finds recent commit touching price; recommendation agent identifies price entry error | ⏳ Pending |
+| F.5 | Scenario 5 — Schema drift | Trigger: monitoring workflow creates issue from Sentry alert; codebase agent detects undefined field in order confirmation; traces to resolver/schema gap; recommendation agent recommends running validate-schema.js | ⏳ Pending |
+| F.6 | False positive check | Run monitoring workflow against a clean system with no active issues; confirm no issue is created and no agent is invoked | ⏳ Pending |
+| F.7 | Prompt injection check | Introduce a synthetic Sentry error with an injection payload in the message; confirm agent sets `injection_flag: true`, stops processing the source, and orchestrator opens a `security-incident` flagged issue | ⏳ Pending |
 
 ---
 
 ## Dependencies
 
 ```
-A.1 (backend Sentry) → B.1 (Sentry Agent can read backend errors)
-A.2 (release tagging) → B.1 (errors map to deployments)
-A.3 (test scenarios) → B.1–B.5 (acceptance criteria)
-A.4 (runbook) → B.4 (Codebase Agent reads runbook)
-A.5 (Render API) → B.2 (Render Logs Agent)
-B.1–B.5 (all agents) → C.2 (Orchestrator)
-C.2 (Orchestrator) → C.3, C.4, C.5
-C.2–C.5 → D.1–D.6
+A.1 (backend Sentry) ──────────────────────────────→ D.2 (Backend Sentry Agent)
+A.2 (release tagging) ─────────────────────────────→ D.2 (errors map to deployments)
+A.3 (frontend Sentry) ─────────────────────────────→ D.1 (Frontend Sentry Agent)
+A.4 (test scenarios) ──────────────────────────────→ D.1–D.6 (acceptance criteria)
+A.5 (runbook) ─────────────────────────────────────→ D.5 (Codebase Agent reads runbook)
+A.6 (Render API) ──────────────────────────────────→ D.3 (Render Logs Agent)
+
+B.1 (agents/ package) ─────────────────────────────→ B.2, B.3, B.4, all of D and E
+B.2 (finding schema) ──────────────────────────────→ B.3 (validator), D.1–D.6 (agents conform to schema)
+B.3 (schema validator) ────────────────────────────→ E.2 (orchestrator validates before routing)
+B.4 (model config) ────────────────────────────────→ D.1–D.6, E.2
+
+C.1 (backend monitor workflow) ────────────────────→ C.3 (orchestrator triggered by label)
+C.2 (frontend monitor workflow) ───────────────────→ C.3 (orchestrator triggered by label)
+C.3 (agent-orchestrator.yml) ──────────────────────→ E.2 (entry point for automated path)
+
+D.1–D.6 (all agents) ──────────────────────────────→ E.2 (Orchestrator invokes them)
+E.2 (Orchestrator) ────────────────────────────────→ E.3, E.4, E.5, E.6
+E.2–E.6 (full orchestration) ──────────────────────→ F.1–F.7
 ```


### PR DESCRIPTION
Architecture changes:
- Add Agent Runtime section: Python SDK package (agents/), tool-based authorization boundary, entry points, per-agent model selection table
- Add Finding Schema section: YAML envelope, required fields, finding-schema.json location in agents/schemas/, schema_version, agent-finding HTML tag
- Add Cost Reference section: per-agent token estimates, monthly projections, prompt caching and mixed model levers
- Replace line-number index with anchor links
- Add Appendix with 7 design decisions from 2026-04-29 session

Execution plan changes:
- Add Phase B: agents/ package foundation (schema file, validator, model config)
- Add Phase C: monitoring workflows (sentry-monitor-frontend/backend, orchestrator trigger)
- Split single Sentry Agent into Frontend (D.1) and Backend (D.2) agents
- Fix Phase E trigger types: 3 triggers, no direct Sentry webhooks
- Add E.4 tool-list authorization gating and compliance flag logic
- Add E.5 confidence-gated notifications, E.6 timeout/escalation
- Add F.7 prompt injection validation scenario
- Update dependency graph to reflect new phases