### PR TITLE
docs(agents): align observability contract and architecture doc befor…

### DIFF
--- a/agents/specs/dt13_agent_observability.md
+++ b/agents/specs/dt13_agent_observability.md
@@ -33,9 +33,9 @@ Called once at the end of every `run()` after the agentic loop completes.
 2. Creates a Sentry transaction named `agent.run` with tag `agent=<agent_name>`
 3. Reads `status` and `confidence` from the result dict (`result.get("status")`, `result.get("confidence", "")`)
 4. Sums `input_tokens`, `output_tokens`, `total_tokens` across all turns
-5. Records measurements: `input_tokens`, `output_tokens`, `total_tokens`, `turns_used`, `confidence_numeric` (high=3, medium=2, low=1)
-6. Sets transaction status: `ok` for `completed`, `deadline_exceeded` for `partial`
-7. Finishes the transaction
+5. Records tags: `agent`, `status`, `issue_number` (empty string if not provided — still queryable)
+6. Records extra: `input_tokens`, `output_tokens`, `total_tokens`, `turns_used`, `confidence_numeric` (high=3, medium=2, low=1), `usage_by_turn` (raw list preserved for per-turn drill-down)
+7. Calls `capture_event` — `issue_number` tag groups all agents from one investigation; `usage_by_turn` in extra shows token growth across turns for troubleshooting
 
 **Signature:**
 ```python
@@ -43,6 +43,7 @@ def record_agent_run(
     agent_name: str,
     result: dict,              # structured dict returned by run(); not a YAML string
     usage_by_turn: list[dict], # each dict: {"input_tokens": int, "output_tokens": int}
+    issue_number: str = "",    # GitHub Issue number — groups all agents from one investigation
 ) -> None
 ```
 
@@ -126,10 +127,12 @@ Create a dashboard named `Agent Observability` with:
 
 Tests must be written before implementation (red phase first):
 
-1. `test_record_agent_run_completed` — mock `sentry_sdk`; pass a `{"status": "completed", "confidence": "high"}` dict and 2-turn usage; assert transaction name, tag, measurements, and `ok` status were set
-2. `test_record_agent_run_partial` — pass a `{"status": "partial", "confidence": "low"}` dict; assert `deadline_exceeded` status
+1. `test_record_agent_run_completed` — mock `sentry_sdk`; pass a `{"status": "completed", "confidence": "high"}` dict, 2-turn usage, and `issue_number="47"`; assert `tags["agent"]`, `tags["status"]`, `tags["issue_number"]`, `extra["input_tokens"]`, `extra["output_tokens"]`, `extra["total_tokens"]`, `extra["turns_used"]`, `extra["confidence_numeric"]`, and `extra["usage_by_turn"]` (full list preserved)
+2. `test_record_agent_run_partial` — pass a `{"status": "partial", "confidence": "low"}` dict; assert `tags["status"] == "partial"` and `extra["confidence_numeric"] == 1`
 3. `test_record_agent_run_no_dsn` — `AGENTS_SENTRY_DSN` not set; assert function returns without calling `sentry_sdk.init` (observability is opt-in)
 4. `test_confidence_numeric_mapping` — high=3, medium=2, low=1, missing=0
+5. `test_record_agent_run_issue_number_tag` — pass `issue_number="123"`; assert `event["tags"]["issue_number"] == "123"`
+6. `test_record_agent_run_usage_by_turn_preserved` — pass 3-turn usage list; assert `event["extra"]["usage_by_turn"]` equals the exact input list (not summed)
 
 ---
 
@@ -145,36 +148,9 @@ Tests must be written before implementation (red phase first):
 ### Sentry Performance not available on free plan
 `start_transaction()` sent events but they did not appear in the Performance tab.
 Sentry confirmed Performance requires a paid plan for full visibility.
-**Decision:** Switch `record_agent_run()` to `capture_event()` — works on all plans,
-lands in Issues/Events, fully queryable in dashboards via tags and extras.
-**Status: Pending** — `sentry_utils.py` still uses `start_transaction`. Must be done before D.2.
-
-### Tool result trimming — token cost dropped from 26k to 5k per run
-Raw API responses were being passed directly into LLM context:
-- `query_sentry_errors` was fetching 25 full issue objects with no time boundary
-- `get_stack_trace` was returning the full event payload (breadcrumbs, headers, all frames)
-
-**Fixes applied:**
-- `query_sentry_errors` — `age:-1h` Sentry query filter (not a `start` param — Sentry query syntax); limit reduced to 3; response trimmed to 6 fields per issue
-- `get_stack_trace` — trimmed to `exception_type`, `exception_message`, `culprit`, top 2 frames only
-
-**Orchestrator note:** The orchestrator (Phase E) should pass a specific `issue_id` directly
-to the agent rather than relying on `query_sentry_errors` to browse. At that point
-`query_sentry_errors` becomes a discovery tool only, not the primary input path.
-
-### Claude wraps YAML in markdown code fences
-Despite prompt instruction "no prose before or after", Claude wraps output in ` ```yaml ` fences.
-`_strip_code_fence()` added to `sentry_utils.py` as a defensive strip before `yaml.safe_load()`.
-This helper is now unused since extractors return dicts — it can be removed when `sentry_utils.py`
-is updated to accept `result: dict`.
-
-### DT-15 — extractors return dicts, not YAML strings (2026-05-04)
-`frontend_sentry_extractor.py` was refactored to a pure Python escalating window loop that returns
-a structured `dict` directly. `record_agent_run` signature must be updated from `result_yaml: str`
-to `result: dict` before D.2. The YAML parsing logic (`yaml.safe_load`, `_strip_code_fence`,
-`metadata.status` / `metadata.confidence` keys) must be replaced with direct dict key access
-(`result.get("status")`, `result.get("confidence", "")`).
-**Status: Pending** — `sentry_utils.py` and `test_sentry_utils.py` not yet updated.
+**Decision:** `capture_event()` used instead — works on all plans, lands in Issues/Events,
+fully queryable in dashboards via tags and extras.
+**Status: Done (2026-05-05)**
 
 ---
 
@@ -188,6 +164,10 @@ to `result: dict` before D.2. The YAML parsing logic (`yaml.safe_load`, `_strip_
 6. ✅ Update `agents/requirements.txt`
 7. ✅ Update `agents/.env.example`
 8. ✅ Wire `record_agent_run` into `frontend_sentry_extractor.py`
-9. ⬜ Update `record_agent_run` signature to `result: dict` — remove YAML parsing, `_strip_code_fence`, update `test_sentry_utils.py` (blocked by DT-15 findings, must be done before D.2)
-10. ⬜ Switch to `capture_event()` — free-plan compatible (blocked by free-plan finding, must be done before D.2)
-11. ⬜ Build Sentry dashboard
+9. ✅ Update `record_agent_run` signature to `result: dict` — YAML parsing and `_strip_code_fence` removed (done 2026-05-05 as part of DT-15)
+10. ✅ Switch to `capture_event()` — free-plan compatible (done 2026-05-05)
+11. ⬜ Add `issue_number: str = ""` param — tag groups all agents from one investigation in Sentry
+12. ⬜ Add `usage_by_turn` list to `extra` — preserves per-turn token data for troubleshooting token growth across turns
+13. ⬜ Update `test_sentry_utils.py` — assert `issue_number` tag and `usage_by_turn` in extra (tests 5 and 6 above)
+14. ⬜ Wire `issue_number` into Orchestrator → passed to each agent's `run()` → forwarded to `record_agent_run` (E.2)
+15. ⬜ Build Sentry dashboard — filter by `issue_number` to see all agents per investigation; `usage_by_turn` visible in event detail

--- a/docs/engineering-practices/agent-architecture.md
+++ b/docs/engineering-practices/agent-architecture.md
@@ -200,7 +200,7 @@ Frame limit config key: `SENTRY_STACK_FRAME_LIMIT` (default: `3`).
 
 Sentry agents make zero Claude API calls. The agent returns a Python dict of structured findings only — no interpretation. The Orchestrator assembles `metadata` around these findings; the Recommendation Agent adds `interpretation` in the single cross-source Claude call.
 
-**What the Python extractor returns to the Orchestrator (zero Claude tokens):**
+**Frontend Sentry Extractor — what it returns to the Orchestrator (zero Claude tokens):**
 ```python
 {
     "id":               "4823910",
@@ -219,6 +219,31 @@ Sentry agents make zero Claude API calls. The agent returns a Python dict of str
         {"filename": "src/components/MenuItemCard.tsx", "lineno": 42, "function": "render"},
         {"filename": "src/pages/MenuPage.tsx",          "lineno": 87, "function": "MenuPage"},
         {"filename": "src/hooks/useMenuItems.ts",       "lineno": 23, "function": "useMenuItems"}
+    ]
+}
+```
+
+**Backend Sentry Extractor — same shape plus `endpoint` and `http_status`:**
+```python
+{
+    "id":               "5910234",
+    "title":            "ValueError: Reservation date must be at least 24 hours in advance",
+    "level":            "error",
+    "culprit":          "backend/reservations/service.py in create_reservation",
+    "count":            87,
+    "user_count":       23,
+    "is_unhandled":     False,
+    "first_seen":       "2026-05-07T14:02:00Z",
+    "last_seen":        "2026-05-07T14:55:00Z",
+    "release":          "cfe6747",
+    "exception_type":   "ValueError",
+    "exception_message":"Reservation date must be at least 24 hours in advance",
+    "endpoint":         "POST /api/reservations",
+    "http_status":      422,
+    "top_frames": [
+        {"filename": "backend/reservations/service.py",  "lineno": 34, "function": "create_reservation"},
+        {"filename": "backend/reservations/router.py",   "lineno": 19, "function": "create"},
+        {"filename": "backend/main.py",                  "lineno": 8,  "function": "app"}
     ]
 }
 ```
@@ -280,7 +305,7 @@ agents/
   backend_sentry_extractor.py
   render_logs_extractor.py
   github_extractor.py
-  codebase_extractor.py
+  codebase_agent.py
   recommendation_agent.py
 ```
 
@@ -943,19 +968,27 @@ Every `run()` call records a Sentry transaction before returning — regardless 
 | `turns_used` | Count of loop iterations | High turns = agent struggled; budget may need adjustment |
 | `confidence_numeric` | `high=3`, `medium=2`, `low=1` | Enables confidence trend charts in Sentry |
 | `status` | `completed` / `partial` / `no_data` / `injection_detected` | Partial run rate is a leading indicator of budget problems |
+| `issue_number` | GitHub Issue number passed from Orchestrator | Groups all agent events from one investigation in Sentry — filter by `issue_number:47` to see all agents side by side |
+| `usage_by_turn` | Raw list of per-turn usage dicts | Preserved in event `extra` for turn-by-turn drill-down — shows token growth across turns, not just totals |
 
 ### Implementation Contract
 
-`record_agent_run(agent_name, result, usage_by_turn)` in `agents/sentry_utils.py` is the single function responsible for all Sentry instrumentation.
+`record_agent_run(agent_name, result, usage_by_turn, issue_number="")` in `agents/sentry_utils.py` is the single function responsible for all Sentry instrumentation.
+
+`issue_number` is the GitHub Issue number for the current investigation — it tags every Sentry event so all agents from one investigation are groupable in a single Sentry query (e.g. `issue_number:47`). Passed from the Orchestrator through each agent's `run()` call.
+
+The raw `usage_by_turn` list is preserved in the Sentry event `extra` alongside the summed totals. This enables per-turn token drill-down in the event detail view — useful for diagnosing token growth across turns in the Codebase Agent or Orchestrator.
 
 **Claude-calling components** (Orchestrator, Codebase Agent, Recommendation Agent):
 1. Initialise `usage_by_turn = []` before the agentic loop
 2. Append `{"input_tokens": ..., "output_tokens": ..., "cache_read_input_tokens": ..., "cache_creation_input_tokens": ...}` after every `client.messages.create()` call
-3. Call `record_agent_run()` before **every** return path — including `partial` fallback
+3. Accept `issue_number: str = ""` in `run()` and forward it to `record_agent_run()`
+4. Call `record_agent_run()` before **every** return path — including `partial` fallback
 
 **Pure Python extractors** (Sentry, Render Logs, GitHub — zero Claude calls):
 1. Pass `usage_by_turn = []` (empty list) to `record_agent_run()` — no Anthropic API calls to measure
-2. Call `record_agent_run()` before **every** return path — including `no_data` and `injection_detected` exits
+2. Accept `issue_number: str = ""` in `run()` and forward it to `record_agent_run()`
+3. Call `record_agent_run()` before **every** return path — including `no_data` and `injection_detected` exits
 
 No agent may return without calling `record_agent_run()`. This is enforced by the wiring checklist in `agents/CLAUDE.md`.
 

--- a/docs/engineering-practices/agent-execution-plan.md
+++ b/docs/engineering-practices/agent-execution-plan.md
@@ -1,7 +1,7 @@
 # Agent Implementation Execution Plan — Aap ki Rasoi
 
 **Status: IN PROGRESS**
-**Last updated: 2026-05-04**
+**Last updated: 2026-05-07**
 **Reference:** See `docs/engineering-practices/agent-architecture.md` for design decisions, access matrix, and finding schema.
 **Master plan reference:** See `execution-plan.md` — Phase 3, Agentic Workflows.
 
@@ -9,9 +9,9 @@
 
 ## Current Focus
 
-**Next: DT-15 — Refactor D.1 to pure Python extractor, then D.2 spec.**
+**Next: D.2 — Backend Sentry Extractor.**
 
-Architecture decisions are all resolved (see below). D.1 (`frontend_sentry_extractor.py`) was built under the old per-agent Claude call design and still has an agentic loop inside. Before building D.2, D.1 must be refactored to match the new architecture — pure Python, zero Claude calls, `run(guardrails: dict) -> dict` signature.
+D.1 refactor (DT-15) is complete. Architecture doc and execution plan are fully aligned. D.2 spec to be written before implementation — architecture doc has the full contract (Backend Sentry return dict, Sentry Query Contract, observability wiring, guardrails).
 
 ---
 
@@ -41,7 +41,7 @@ Yes — Sentry query contract is documented in the architecture doc. Render Logs
 Elevated to Principle 9 in architecture doc. Applies to all extractors — raw API responses never reach the Orchestrator or Recommendation Agent.
 
 **Q6 — Prompt caching strategy** ✅ resolved
-Only the Recommendation Agent uses the Anthropic SDK — prompt caching applies to that agent only. `build_system_prompt()` wraps its system prompt with `cache_control`. Extractors make zero Claude API calls so caching is not applicable to them.
+Three components call the Anthropic SDK — Orchestrator, Codebase Agent, and Recommendation Agent. All three must use `build_system_prompt()` to wrap their system prompt with `cache_control`. System prompts do not change between runs so every subsequent call should hit the cache (~90% cheaper on input tokens). Pure Python extractors make zero Claude API calls so caching is not applicable to them.
 
 **Q7 — Recommendation Agent payload — who strips?** ✅ resolved
 The Orchestrator is responsible for the combined payload size. Each extractor already trims to minimum fields at its own boundary. The Orchestrator enforces the final combined token cap before passing to the Recommendation Agent — no further stripping inside Claude's context.
@@ -82,9 +82,33 @@ def run(guardrails: dict) -> dict:
 
 ---
 
+## Session Progress (2026-05-07)
+
+**Architecture doc and execution plan aligned. Ready for D.2.**
+
+### Architecture doc audit ✅
+Cross-checked execution plan against architecture doc. Five fixes applied to execution plan:
+- DT-14 rewritten — now covers all three gaps: `issue_number` tag, `usage_by_turn` in extra, cache token fields; scoped to all three Claude callers (Orchestrator, Codebase Agent, Recommendation Agent)
+- "Backend Sentry Agent" → "Backend Sentry Extractor" in session heading
+- "Codebase Extractor" → "Codebase Agent" in Guiding Principles
+- B.5 dependency corrected — prompt caching applies to D.5, D.6, E.2 only (not D.1–D.4)
+- Current Focus updated — DT-15 done, next is D.2
+
+Three fixes applied to architecture doc:
+- Backend Sentry return dict added — full example showing `endpoint` and `http_status` fields
+- `record_agent_run` signature updated — `issue_number: str = ""` added; `usage_by_turn` in extra documented; `issue_number` flow (Orchestrator → agent `run()` → `record_agent_run`) documented
+- `usage_by_turn` and `issue_number` added to "What Is Logged Per Run" table
+- Directory structure: `codebase_extractor.py` → `codebase_agent.py`
+
+### DT-13 spec cleaned up ✅
+- Post-Implementation Findings trimmed — only the `capture_event` rationale kept (Sentry Performance requires paid plan); stale YAML/DT-15 findings removed
+- Signature, TDD section, and sequence of work updated to reflect `issue_number` and `usage_by_turn` additions (steps 11–15)
+
+---
+
 ## Session Progress (2026-05-03)
 
-**DT-13 complete. Next: D.2 Backend Sentry Agent.**
+**DT-13 complete. Next: D.2 Backend Sentry Extractor.**
 
 ### DT-13 — Agent Observability via Sentry ✅ complete (2026-05-03), updated 2026-05-05
 - `agents/sentry_utils.py` — `record_agent_run(agent_name, result: dict, usage_by_turn)` uses `capture_event` (not `start_transaction` — Performance tab requires paid plan); signature updated from `result_yaml: str` to `result: dict` after DT-15
@@ -94,11 +118,13 @@ def run(guardrails: dict) -> dict:
 - `agents/tests/test_frontend_sentry_extractor.py` — `record_agent_run` mocked to prevent real Sentry calls
 - `agents/CLAUDE.md` — observability guardrail + token efficiency rules + wiring checklist
 
-**DT-13 gap identified (2026-05-04):** `usage_by_turn` currently captures only `input_tokens` and `output_tokens`. Two cache fields are missing:
-- `cache_read_input_tokens` — tokens served from prompt cache (billed at 10% rate)
-- `cache_creation_input_tokens` — tokens written to cache on first call
+**DT-13 gaps identified (2026-05-04 / 2026-05-07):**
 
-These must be added to `usage_by_turn` in every agent and summed in `record_agent_run()`. Without them the Sentry dashboard cannot show true cost (cache reads are 10x cheaper and skew the total). Tracked as **DT-14** below.
+`usage_by_turn` currently captures only `input_tokens` and `output_tokens`. Three additions are needed — tracked as **DT-14** below:
+
+1. **Cache token fields** — `cache_read_input_tokens` and `cache_creation_input_tokens` missing; cache reads cost 10% of normal rate and skew the total without them
+2. **`issue_number` tag** — no correlation ID today; without it, Sentry cannot group all agents from one investigation together; pass GitHub Issue number from Orchestrator → each agent's `run()` → `record_agent_run`
+3. **`usage_by_turn` in extra** — raw per-turn list is currently summed away; preserving it in the Sentry event `extra` enables drill-down to diagnose token growth across turns
 
 ---
 
@@ -114,18 +140,29 @@ These must be added to `usage_by_turn` in every agent and summed in `record_agen
 
 ---
 
-### DT-14 — Capture Cache Token Usage ⏳ pending
+### DT-14 — Complete Observability Contract ⏳ pending
 
-Add `cache_read_input_tokens` and `cache_creation_input_tokens` to `usage_by_turn` in the Recommendation Agent and update `record_agent_run()` to sum them.
-
-**Why:** The Recommendation Agent uses `build_system_prompt()` with `cache_control`. Cache reads cost 10% of normal input token price. Without capturing these fields the token cost reported in Sentry is incorrect. Extractors make zero Claude API calls so this does not apply to them.
+**Why:** Three gaps in `record_agent_run` prevent full token visibility in Sentry: missing cache fields skew cost reporting; no `issue_number` tag means agent events from the same investigation cannot be grouped; `usage_by_turn` list is summed away so per-turn token growth is invisible.
 
 **Scope:**
-1. Update `usage_by_turn.append()` in `recommendation_agent.py` to include both cache fields
-2. Update `record_agent_run()` in `sentry_utils.py` to sum and record `cache_read_input_tokens` and `cache_creation_input_tokens` as separate Sentry measurements
-3. Extractors pass `usage_by_turn = []` (empty) — no change needed there
 
-**Reference:** Architecture doc — Agent Observability section, implementation contract.
+*`agents/sentry_utils.py`:*
+1. Add `issue_number: str = ""` to `record_agent_run` signature — add as `tags["issue_number"]`
+2. Add `usage_by_turn` list to `extra` — preserves per-turn data for troubleshooting token growth across turns
+3. Sum `cache_read_input_tokens` and `cache_creation_input_tokens` from `usage_by_turn`; record as separate `extra` fields
+
+*`agents/tests/test_sentry_utils.py`:*
+4. Add `test_record_agent_run_issue_number_tag` — assert `event["tags"]["issue_number"] == "123"`
+5. Add `test_record_agent_run_usage_by_turn_preserved` — assert `event["extra"]["usage_by_turn"]` equals input list exactly
+
+*Claude-calling agents — all three (Orchestrator, Codebase Agent, Recommendation Agent):*
+6. Each turn's `usage_by_turn.append()` must include `cache_read_input_tokens` and `cache_creation_input_tokens`
+7. Each `run()` must accept `issue_number: str = ""` and forward it to `record_agent_run`
+8. Extractors pass `usage_by_turn = []` (empty) — no change needed there
+
+**Dashboard outcome:** Filter Sentry by `issue_number:47` → see all agents for that investigation with token totals. Open any event → `usage_by_turn` shows turn-by-turn token growth.
+
+**Reference:** `agents/specs/dt13_agent_observability.md` — steps 11–14.
 - `.gitignore` — `agents/__pycache__/` patterns added
 - `agents/specs/dt13_agent_observability.md` — post-implementation findings documented
 - PR: `feat/dt13-agent-observability` — 5/5 tests passing
@@ -234,7 +271,7 @@ Files created:
 - Test scenarios (`docs/agent-test-scenarios.md`) are the acceptance criteria — an agent is not done until it passes its relevant scenarios.
 - Runbook must be updated before each agent is built — agents read the runbook, not the other way around.
 - No agent writes to external systems until the orchestration layer is complete and authorization logic is in place.
-- D.1–D.4 extractors (Sentry, Render, GitHub) are pure Python — zero Claude API calls. D.5 (Codebase Extractor) uses Claude for navigation only — read-only filesystem, no write access anywhere. D.6 (Recommendation Agent) uses Claude for cross-source synthesis and opens draft PRs — GitHub write access, no codebase read access. No Claude Code sub-agents anywhere.
+- D.1–D.4 extractors (Sentry, Render, GitHub) are pure Python — zero Claude API calls. D.5 (Codebase Agent) uses Claude for navigation only — read-only filesystem, no write access anywhere. D.6 (Recommendation Agent) uses Claude for cross-source synthesis and opens draft PRs — GitHub write access, no codebase read access. No Claude Code sub-agents anywhere.
 
 ---
 
@@ -341,7 +378,7 @@ B.1 (agents/ package) ───────────────────�
 B.2 (finding schema) ──────────────────────────────→ B.3 (validator), D.1–D.6 (agents conform to schema)
 B.3 (schema validator) ────────────────────────────→ E.2 (orchestrator validates before routing)
 B.4 (model config) ────────────────────────────────→ D.1–D.6, E.2
-B.5 (prompt caching) ──────────────────────────────→ D.1–D.6, E.2 (all agents must cache system prompts)
+B.5 (prompt caching) ──────────────────────────────→ D.5, D.6, E.2 only (Claude callers only — D.1–D.4 are pure Python extractors with zero Claude calls)
 
 C.1 (backend monitor workflow) ────────────────────→ C.3 (orchestrator triggered by label)
 C.2 (frontend monitor workflow) ───────────────────→ C.3 (orchestrator triggered by label)


### PR DESCRIPTION
…e D.2

- record_agent_run signature: add issue_number param (groups all agents from one investigation in Sentry) and preserve usage_by_turn list in extra (per-turn token drill-down for troubleshooting token growth)
- Architecture doc: backend Sentry return dict added with endpoint and http_status fields; codebase_extractor.py renamed to codebase_agent.py in directory structure; What Is Logged table updated with issue_number and usage_by_turn entries
- DT-14 rewritten: covers all three gaps (issue_number tag, usage_by_turn in extra, cache token fields) scoped to all three Claude callers
- Execution plan naming fixes: Backend Sentry Extractor (not Agent), Codebase Agent (not Extractor), B.5 prompt caching scoped to D.5/D.6/E.2
- DT-13 spec: Post-Implementation Findings trimmed to capture_event rationale only; stale YAML/DT-15 findings removed