### PR TITLE
docs(agents): D.4 GitHub Extractor spec, query contract, config const…

### DIFF
--- a/agents/config.py
+++ b/agents/config.py
@@ -57,3 +57,13 @@ RENDER_API_KEY = os.getenv("RENDER_API_KEY", "")
 RENDER_LOG_FETCH_LIMIT = int(os.getenv("RENDER_LOG_FETCH_LIMIT", "500"))
 RENDER_MAX_DISTINCT_ERRORS = int(os.getenv("RENDER_MAX_DISTINCT_ERRORS", "10"))
 RENDER_LOG_MAX_MSG_LEN = int(os.getenv("RENDER_LOG_MAX_MSG_LEN", "300"))
+
+# why: GitHub API requires repo slug and token from env — never hardcoded
+GITHUB_API_BASE = "https://api.github.com"
+GITHUB_REPO = os.getenv("GITHUB_REPO", "")
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "")
+GITHUB_BRANCH = os.getenv("GITHUB_BRANCH", "main")
+
+# why: guardrails for GitHub commit extraction — Orchestrator overrides per run
+GITHUB_MAX_COMMITS = int(os.getenv("GITHUB_MAX_COMMITS", "20"))
+GITHUB_MSG_MAX_LEN = int(os.getenv("GITHUB_MSG_MAX_LEN", "100"))

--- a/agents/specs/d4_github_extractor.md
+++ b/agents/specs/d4_github_extractor.md
@@ -1,0 +1,144 @@
+# D.4 — GitHub Extractor Spec
+
+**Status: DRAFT — awaiting sign-off**
+**Architecture doc sections:** `GitHub Agent Query Contract`, `Agent Catalog`, `Finding Schema`, `GitHub Findings Schema`
+**Dependency map:** `agents/specs/DEPENDENCY_MAP.md`
+
+---
+
+## What this slice builds
+
+A pure Python extractor (`agents/github_extractor.py`) that queries the GitHub REST API to fetch commits that went into the release where the error first appeared, and returns a structured dict to the Orchestrator. Zero Claude API calls.
+
+---
+
+## Signature
+
+```python
+# agents/github_extractor.py
+def run(guardrails: dict, issue_number: str = "") -> dict:
+    ...
+```
+
+**Guardrails consumed:**
+
+| Key | Type | Source | Notes |
+|---|---|---|---|
+| `max_commits` | `int` | Orchestrator | Overrides `GITHUB_MAX_COMMITS`; defaults to config value if absent |
+| `release_sha` | `str \| None` | Orchestrator | Sentry release SHA; if provided, walk commits backwards from this SHA (not HEAD) — these are the commits that went into the failing release |
+
+---
+
+## Return Shape
+
+Matches the `GitHub Findings Schema` section in `agent-architecture.md`.
+
+```python
+{
+    "status": "completed",        # "completed" | "no_data" | "injection_detected"
+    "source": "github",
+    "commit_window": {
+        "branch": "main",
+        "from_sha": "a3f9c12",   # oldest commit returned (N commits before the anchor)
+        "to_sha":   "cfe6747"    # release_sha anchor, or HEAD if no release_sha provided
+    },
+    "commit_count": 2,
+    "commits": [
+        {
+            "sha": "cfe6747",
+            "message": "fix: remove allergens from useMenu GraphQL query",
+            "author": "vikasparth",
+            "committed_at": "2026-05-04T08:45:00Z",
+            "changed_files": ["src/hooks/useMenu.ts", "src/features/menu/types.ts"]
+        }
+    ],
+    "injection_flag": False,
+    "pii_flag": False
+}
+```
+
+---
+
+## Implementation Rules
+
+1. Import `GITHUB_API_BASE`, `GITHUB_REPO`, `GITHUB_TOKEN`, `GITHUB_BRANCH`, `GITHUB_MAX_COMMITS`, `GITHUB_MSG_MAX_LEN` from `agents/config.py` — never hardcode.
+2. Import `_INJECTION_RE`, `_EMAIL_RE`, `_PHONE_RE` from `agents/patterns.py` — never redefine locally.
+3. Import `record_agent_run` from `agents/sentry_utils.py` — call it before every `return`.
+4. Use `STATUS_COMPLETED`, `STATUS_NO_DATA`, `STATUS_INJECTION_DETECTED` constants from `agents/config.py`.
+5. `usage_by_turn = []` — pure Python extractor, no Claude calls, list stays empty.
+6. Author email must be dropped unconditionally — keep only GitHub `login` field.
+7. Commit message trimmed to first line, capped at `GITHUB_MSG_MAX_LEN` chars.
+8. Each commit detail call (`GET /repos/{repo}/commits/{sha}`) fetches changed files — keep only `filename`.
+
+---
+
+## Filtering Pipeline (ordered)
+
+1. **Choose the walk anchor** — if `release_sha` is non-empty, set `sha={release_sha}` in the query; otherwise use `sha={GITHUB_BRANCH}` (HEAD). The GitHub API walks backwards from the given SHA, so passing the release SHA returns the commits that went into that release, not commits made after it.
+2. **Fetch commit list** — `GET /repos/{repo}/commits?sha={anchor}&per_page={max_commits}`. Returns up to `max_commits` commits walking backwards from the anchor.
+3. **Injection check** — for each commit message, test against `_INJECTION_RE`. On match → `injection_flag=True`, return immediately.
+4. **PII check** — for each commit message, test against `_EMAIL_RE` and `_PHONE_RE`. On match → `pii_flag=True` (do not return early — strip the match and continue). Author email is always dropped unconditionally regardless of this flag.
+5. **Trim message** — keep first line only, capped at `GITHUB_MSG_MAX_LEN` chars.
+6. **Fetch changed files** — for each commit, call `GET /repos/{repo}/commits/{sha}` and extract `files[*].filename`.
+
+---
+
+## Private Helper Functions
+
+```python
+def _fetch_commits(anchor_sha: str, max_commits: int) -> list[dict]:
+    # GET /repos/{GITHUB_REPO}/commits?sha={anchor_sha}&per_page={max_commits}
+    # anchor_sha is release_sha when provided, otherwise GITHUB_BRANCH (HEAD)
+    ...
+
+def _fetch_changed_files(sha: str) -> list[str]:
+    # GET /repos/{GITHUB_REPO}/commits/{sha} — returns filenames only
+    ...
+
+def _trim_commit(raw: dict) -> dict:
+    # injection check, PII check, message trim, drop email
+    # returns trimmed dict with injection_flag and pii_flag as side-channel bools
+    ...
+```
+
+Return flags (`injection_flag`, `pii_flag`) are accumulated across all commits in `run()` — a single True anywhere in the list sets the top-level flag.
+
+---
+
+## TDD Test Plan
+
+File: `agents/tests/test_github_extractor.py`
+
+| # | Test name | What it verifies |
+|---|---|---|
+| 1 | `test_returns_completed_with_commits` | Happy path: 3 commits returned → `status="completed"`, correct `commit_count`, `source="github"` |
+| 2 | `test_no_data_when_api_returns_empty` | API returns `[]` → `status="no_data"`, `commit_count=0` |
+| 3 | `test_injection_in_commit_message_returns_early` | One commit message contains injection pattern → `status="injection_detected"`, `injection_flag=True` |
+| 4 | `test_author_email_is_stripped` | Raw GitHub response includes author email → returned dict has no email field anywhere |
+| 5 | `test_release_sha_used_as_walk_anchor` | `release_sha` provided → fetch called with `sha=release_sha`, not `sha=GITHUB_BRANCH` |
+| 6 | `test_message_trimmed_to_first_line_and_capped` | Multi-line commit message → only first line returned, capped at `GITHUB_MSG_MAX_LEN` |
+| 7 | `test_record_agent_run_called_on_every_return` | Mock `record_agent_run` — assert it is called for both completed and no_data paths |
+
+All HTTP calls mocked with `unittest.mock.patch`. No real GitHub API calls in tests.
+
+---
+
+## Files Touched
+
+| File | Change |
+|---|---|
+| `agents/github_extractor.py` | New — implementation |
+| `agents/tests/test_github_extractor.py` | New — 7 TDD tests |
+| `agents/specs/DEPENDENCY_MAP.md` | Update — add `github_extractor` row and new config constants |
+| `agents/.env.example` | Add `GITHUB_REPO`, `GITHUB_TOKEN`, `GITHUB_BRANCH` entries |
+
+---
+
+## Acceptance Criteria
+
+- [ ] All 7 tests green
+- [ ] Full test suite green (no regressions — currently 25 tests)
+- [ ] No real GitHub API calls in tests (all mocked)
+- [ ] `record_agent_run` called on every return path
+- [ ] No hardcoded values — all config from `agents/config.py`
+- [ ] No cross-feature imports — all shared helpers from `patterns.py`, `sentry_utils.py`, `config.py`

--- a/docs/engineering-practices/agent-architecture.md
+++ b/docs/engineering-practices/agent-architecture.md
@@ -15,6 +15,7 @@
 | [Agent Catalog](#agent-catalog) | Frontend Sentry, Backend Sentry, Render Logs, GitHub, Codebase, Recommendation, Orchestrator |
 | [Sentry Agent Query Contract](#sentry-agent-query-contract) | Investigation flow, minimum data fields, time window escalation, exit conditions, guardrails |
 | [Render Agent Query Contract](#render-agent-query-contract) | API endpoint, log filtering, deduplication, guardrails, return shape |
+| [GitHub Agent Query Contract](#github-agent-query-contract) | API endpoints, commit filtering, PII trimming, guardrails, return shape |
 | [Agent Runtime](#agent-runtime) | Packaging decision, directory structure, tool definitions, entry points, model selection |
 | [Finding Schema](#finding-schema) | Common YAML envelope, required fields, agent-specific findings schemas (Sentry + Render), schema file location, versioning |
 | [Monitoring Workflows](#monitoring-workflows) | Pipeline overview, de-duplication rule, handoff contract |
@@ -391,6 +392,107 @@ Guardrails are set by the Orchestrator. The extractor never widens its own windo
 
 ---
 
+## GitHub Agent Query Contract
+
+Applies to the GitHub Extractor (`agents/github_extractor.py`). These rules govern which API endpoints are called, how commit data is filtered and trimmed, when the agent stops, and what shape of data it returns.
+
+### API Endpoints
+
+**1. Fetch commit list — GitHub REST API:**
+
+```
+GET https://api.github.com/repos/{GITHUB_REPO}/commits
+```
+
+| Parameter | Source | Notes |
+|---|---|---|
+| `GITHUB_REPO` | `GITHUB_REPO` env var | Format: `{owner}/{repo}`, e.g. `vikasparth/restaurant-main-project` |
+| `Authorization` | `Bearer {GITHUB_TOKEN}` header | Fine-grained PAT with `Contents: Read` and `Metadata: Read` scopes — minimum required |
+| `sha` | `GITHUB_BRANCH` config key (default: `"main"`) | Branch to walk |
+| `per_page` | `GITHUB_MAX_COMMITS` (default: `20`) | Hard cap — never fetch more than this |
+
+If `release_sha` is present in the Orchestrator guardrails, the extractor sets `sha={release_sha}` in the query instead of `sha=GITHUB_BRANCH`. The GitHub API walks backwards from the given SHA, so this returns the commits that went **into** the error-triggering release — not commits made after it.
+
+Config keys: `GITHUB_API_BASE`, `GITHUB_REPO`, `GITHUB_TOKEN`, `GITHUB_BRANCH`, `GITHUB_MAX_COMMITS`.
+
+**2. Fetch changed files per commit — GitHub REST API:**
+
+```
+GET https://api.github.com/repos/{GITHUB_REPO}/commits/{sha}
+```
+
+Called for each commit in the filtered list. The response includes a `files` array. Only the `filename` field is kept — `additions`, `deletions`, `patch`, and `blob_url` are dropped immediately at the boundary.
+
+### Filtering and Trimming Pipeline
+
+The extractor applies the following steps in Python before returning anything to the Orchestrator:
+
+1. **Choose the walk anchor** — if `release_sha` is in guardrails, use it as the `sha` parameter; otherwise use `GITHUB_BRANCH` (HEAD). The GitHub API walks backwards from the anchor, so passing the release SHA returns the commits that went into that release, not commits made after it.
+2. **Fetch commit list** — `GET /repos/{repo}/commits?sha={anchor}&per_page={GITHUB_MAX_COMMITS}`. Returns commits walking backwards from the anchor.
+3. **Injection check** — check each commit message against the injection pattern (`patterns._INJECTION_RE`). If any match, set `injection_flag: true` and return immediately.
+4. **PII check** — GitHub commit author objects include an email field. Drop it unconditionally — keep only the author `login` (GitHub username). Set `pii_flag: true` if the commit message itself contains an email or phone pattern (`patterns._EMAIL_RE`, `patterns._PHONE_RE`).
+5. **Trim commit message** — keep the first line only, capped at `GITHUB_MSG_MAX_LEN` characters. Multi-line bodies are dropped.
+6. **Fetch changed files** — for each commit, call the per-commit endpoint and keep only the `filename` field from each file entry.
+
+### What the GitHub Extractor Returns
+
+Zero Claude API calls. Returns a Python dict of structured findings only.
+
+```python
+{
+    "status": "completed",       # or "no_data" / "injection_detected"
+    "source": "github",
+    "commit_window": {
+        "branch": "main",
+        "from_sha": "a3f9c12",  # oldest commit returned (release SHA anchor when provided)
+        "to_sha":   "cfe6747"   # newest commit (HEAD at time of fetch)
+    },
+    "commit_count": 2,
+    "commits": [
+        {
+            "sha": "cfe6747",
+            "message": "fix: remove allergens from useMenu GraphQL query",
+            "author": "vikasparth",
+            "committed_at": "2026-05-04T08:45:00Z",
+            "changed_files": [
+                "src/hooks/useMenu.ts",
+                "src/features/menu/types.ts"
+            ]
+        },
+        {
+            "sha": "a3f9c12",
+            "message": "feat: GraphQL gateway menu migration",
+            "author": "vikasparth",
+            "committed_at": "2026-05-04T07:30:00Z",
+            "changed_files": [
+                "graphql-gateway/src/resolvers/menu.ts"
+            ]
+        }
+    ],
+    "injection_flag": False,
+    "pii_flag": False
+}
+```
+
+### Exit Conditions
+
+| Status | Trigger |
+|---|---|
+| `completed` | At least one commit found in the filtered window |
+| `no_data` | Zero commits found after filtering (branch is empty or all commits pre-date the release SHA) |
+| `injection_detected` | Injection pattern matched in any commit message — return immediately, do not process further |
+
+### Guardrails Summary
+
+Guardrails are set by the Orchestrator. The extractor never fetches more than the guardrails allow.
+
+| Guardrail | Config key | Default |
+|---|---|---|
+| Max commits fetched | `GITHUB_MAX_COMMITS` | `20` |
+| Commit message max length | `GITHUB_MSG_MAX_LEN` | `100` chars |
+
+---
+
 ## Agent Runtime
 
 **Decision:** Agents are implemented as a Python package (`agents/`) using the Anthropic SDK with tool use. This is not Claude Code sub-agents — each agent is a focused, stateless agentic loop that runs as a Python script invoked from GitHub Actions or the `/troubleshoot` skill.
@@ -654,6 +756,59 @@ Fields dropped: breadcrumbs, request headers, environment variables, user object
 **Estimated token cost:** ~63 tokens per distinct error. At cap of 10 errors: ~692 tokens total (including header fields). Full extractor run target: under 1,200 tokens in the combined payload.
 
 **No interpretation here.** The Render Logs extractor returns the structured dict above and stops. Interpretation (root cause, affected layer, confidence, regression flag) is produced exclusively by the Recommendation Agent after receiving the full combined payload from the Orchestrator.
+
+---
+
+#### GitHub Findings Schema
+
+**What Python extracts from the GitHub API (structured dict returned by the extractor — no interpretation):**
+
+1. Fetch up to `GITHUB_MAX_COMMITS` commits walking backwards from the Sentry release SHA (or HEAD if none provided) — these are the commits that went into the failing release
+2. For each commit: keep SHA (7 chars), first-line message (≤ 100 chars), author login, committed_at timestamp
+3. For each commit: fetch changed file paths — keep `filename` only, drop patch diffs and line counts
+4. Drop author email unconditionally — keep only GitHub username (login)
+
+**Example — structured dict returned by the extractor:**
+
+```python
+{
+    "status": "completed",       # or "no_data" / "injection_detected"
+    "source": "github",
+    "commit_window": {
+        "branch": "main",
+        "from_sha": "a3f9c12",
+        "to_sha":   "cfe6747"
+    },
+    "commit_count": 2,
+    "commits": [
+        {
+            "sha": "cfe6747",
+            "message": "fix: remove allergens from useMenu GraphQL query",
+            "author": "vikasparth",
+            "committed_at": "2026-05-04T08:45:00Z",
+            "changed_files": [
+                "src/hooks/useMenu.ts",
+                "src/features/menu/types.ts"
+            ]
+        },
+        {
+            "sha": "a3f9c12",
+            "message": "feat: GraphQL gateway menu migration",
+            "author": "vikasparth",
+            "committed_at": "2026-05-04T07:30:00Z",
+            "changed_files": [
+                "graphql-gateway/src/resolvers/menu.ts"
+            ]
+        }
+    ],
+    "injection_flag": False,
+    "pii_flag": False
+}
+```
+
+**Estimated token cost:** ~35 tokens per commit (SHA + message + author + date + 2-3 files). At cap of 20 commits: ~700 tokens. Full extractor run target: under 300 tokens in the combined payload (typical investigations involve 1–5 commits since the release SHA).
+
+**No interpretation here.** The GitHub extractor returns the structured dict above and stops. Interpretation (root cause, regression flag, affected layer) is produced exclusively by the Recommendation Agent after receiving the full combined payload from the Orchestrator.
 
 ---
 


### PR DESCRIPTION
…ants

- agents/specs/d4_github_extractor.md — spec with signature, 6-step filtering pipeline, 7 TDD tests, and acceptance criteria; walk anchor uses release_sha (backwards into the failing release) not HEAD
- docs/engineering-practices/agent-architecture.md — GitHub Agent Query Contract section added (index + full section after Render contract); GitHub Findings Schema added under Agent-Specific Findings Schemas
- agents/config.py — 6 new GitHub constants: GITHUB_API_BASE, GITHUB_REPO, GITHUB_TOKEN, GITHUB_BRANCH, GITHUB_MAX_COMMITS, GITHUB_MSG_MAX_LEN