### PR TITLE
feat(agents): sign off D.4 spec and add shared HTTP status constants

### DIFF
--- a/agents/config.py
+++ b/agents/config.py
@@ -47,6 +47,15 @@ SENTRY_STACK_FRAME_LIMIT = int(os.getenv("SENTRY_STACK_FRAME_LIMIT", "3"))
 STATUS_COMPLETED = "completed"
 STATUS_NO_DATA = "no_data"
 STATUS_INJECTION_DETECTED = "injection_detected"
+STATUS_INVALID_INPUT = "invalid_input"
+STATUS_UNAUTHENTICATED = "unauthenticated"
+STATUS_UNAUTHORIZED = "unauthorized"
+STATUS_NOT_FOUND = "not_found"
+STATUS_RATE_LIMITED = "rate_limited"
+STATUS_SERVER_ERROR = "server_error"
+STATUS_TIMEOUT = "timeout"
+STATUS_NETWORK_ERROR = "network_error"
+STATUS_SCHEMA_ERROR = "schema_error"
 
 # why: Render API requires service ID and key from env — never hardcoded
 RENDER_API_BASE = "https://api.render.com/v1"

--- a/agents/specs/d4_github_extractor.md
+++ b/agents/specs/d4_github_extractor.md
@@ -1,6 +1,6 @@
 # D.4 — GitHub Extractor Spec
 
-**Status: DRAFT — awaiting sign-off**
+**Status: APPROVED — signed off by Vikas, 2026-05-14**
 **Architecture doc sections:** `GitHub Agent Query Contract`, `Agent Catalog`, `Finding Schema`, `GitHub Findings Schema`
 **Dependency map:** `agents/specs/DEPENDENCY_MAP.md`
 
@@ -36,7 +36,7 @@ Matches the `GitHub Findings Schema` section in `agent-architecture.md`.
 
 ```python
 {
-    "status": "completed",        # "completed" | "no_data" | "injection_detected"
+    "status": "completed",        # see Exit Conditions for full status set
     "source": "github",
     "commit_window": {
         "branch": "main",
@@ -58,11 +58,17 @@ Matches the `GitHub Findings Schema` section in `agent-architecture.md`.
 }
 ```
 
+Error statuses (`unauthenticated`, `unauthorized`, `rate_limited`, `server_error`, `network_error`, `timeout`, `not_found`, `invalid_input`, `schema_error`) return a minimal dict:
+
+```python
+{"status": "<status>", "source": "github"}
+```
+
 ---
 
 ## Implementation Rules
 
-1. Import `GITHUB_API_BASE`, `GITHUB_REPO`, `GITHUB_TOKEN`, `GITHUB_BRANCH`, `GITHUB_MAX_COMMITS`, `GITHUB_MSG_MAX_LEN` from `agents/config.py` — never hardcode.
+1. Import `GITHUB_API_BASE`, `GITHUB_REPO`, `GITHUB_TOKEN`, `GITHUB_BRANCH`, `GITHUB_MAX_COMMITS`, `GITHUB_MSG_MAX_LEN`, `GITHUB_MAX_FILES_PER_COMMIT` from `agents/config.py` — never hardcode.
 2. Import `_INJECTION_RE`, `_EMAIL_RE`, `_PHONE_RE` from `agents/patterns.py` — never redefine locally.
 3. Import `record_agent_run` from `agents/sentry_utils.py` — call it before every `return`.
 4. Use `STATUS_COMPLETED`, `STATUS_NO_DATA`, `STATUS_INJECTION_DETECTED` constants from `agents/config.py`.
@@ -70,30 +76,57 @@ Matches the `GitHub Findings Schema` section in `agent-architecture.md`.
 6. Author email must be dropped unconditionally — keep only GitHub `login` field.
 7. Commit message trimmed to first line, capped at `GITHUB_MSG_MAX_LEN` chars.
 8. Each commit detail call (`GET /repos/{repo}/commits/{sha}`) fetches changed files — keep only `filename`.
+9. Guardrail validation runs before any HTTP call — invalid input must never reach the GitHub API.
 
 ---
 
 ## Filtering Pipeline (ordered)
 
-1. **Choose the walk anchor** — if `release_sha` is non-empty, set `sha={release_sha}` in the query; otherwise use `sha={GITHUB_BRANCH}` (HEAD). The GitHub API walks backwards from the given SHA, so passing the release SHA returns the commits that went into that release, not commits made after it.
-2. **Fetch commit list** — `GET /repos/{repo}/commits?sha={anchor}&per_page={max_commits}`. Returns up to `max_commits` commits walking backwards from the anchor.
-3. **Injection check** — for each commit message, test against `_INJECTION_RE`. On match → `injection_flag=True`, return immediately.
-4. **PII check** — for each commit message, test against `_EMAIL_RE` and `_PHONE_RE`. On match → `pii_flag=True` (do not return early — strip the match and continue). Author email is always dropped unconditionally regardless of this flag.
-5. **Trim message** — keep first line only, capped at `GITHUB_MSG_MAX_LEN` chars.
-6. **Fetch changed files** — for each commit, call `GET /repos/{repo}/commits/{sha}` and extract `files[*].filename`. Cap the list at `max_files_per_commit` — a large refactor commit must not blow the token budget.
+1. **Validate guardrails** — check types and value ranges before any HTTP call. Return `invalid_input` immediately on failure (see Exit Conditions).
+2. **Check token** — if `GITHUB_TOKEN` is empty, return `unauthenticated` immediately. No HTTP call.
+3. **Choose the walk anchor** — if `release_sha` is non-empty, set `sha={release_sha}` in the query; otherwise use `sha={GITHUB_BRANCH}` (HEAD). The GitHub API walks backwards from the given SHA, so passing the release SHA returns the commits that went into that release, not commits made after it.
+4. **Fetch commit list** — `GET /repos/{repo}/commits?sha={anchor}&per_page={max_commits}`. Handle HTTP error codes and network exceptions before reading the response body (see Exit Conditions).
+5. **Validate response schema** — confirm each commit object has `sha`, `commit.message`, `commit.author.date`, and `author.login`. Return `schema_error` if any are missing.
+6. **Injection check** — for each commit message, test against `_INJECTION_RE`. On match → return `injection_detected` immediately.
+7. **PII check** — for each commit message, test against `_EMAIL_RE` and `_PHONE_RE`. On match → `pii_flag=True` (do not return early — strip the match and continue). Author email is always dropped unconditionally regardless of this flag.
+8. **Trim message** — keep first line only, capped at `GITHUB_MSG_MAX_LEN` chars.
+9. **Fetch changed files** — for each commit, call `GET /repos/{repo}/commits/{sha}` and extract `files[*].filename`. Cap the list at `max_files_per_commit`. Apply the same HTTP error handling as step 4.
+
+---
+
+## Exit Conditions
+
+| Status | Trigger | Orchestrator action |
+|---|---|---|
+| `completed` | At least one commit found in the window | Pass to Recommendation Agent |
+| `no_data` | Zero commits after filtering | Skip GitHub findings in payload |
+| `injection_detected` | Injection pattern matched in any commit message | Flag on GitHub Issue; stop processing |
+| `invalid_input` | Guardrails dict has wrong types or malformed values (e.g. `max_commits="three"`, `release_sha="not-a-sha!!"`, negative int) | Log misconfiguration; skip GitHub findings |
+| `unauthenticated` | `GITHUB_TOKEN` is empty, or API returns 401 | Alert owner — token missing or expired |
+| `unauthorized` | API returns 403 | Alert owner — token lacks required scope (`Contents: Read`) |
+| `not_found` | API returns 404 | Alert owner — `GITHUB_REPO` is wrong or `release_sha` does not exist |
+| `rate_limited` | API returns 429 | Back off; retry at next scheduled run |
+| `server_error` | API returns 5xx | Treat as transient; retry at next scheduled run |
+| `timeout` | `requests` raises `Timeout` | Treat as transient; retry at next scheduled run |
+| `network_error` | `requests` raises `ConnectionError` | Treat as transient; retry at next scheduled run |
+| `schema_error` | Response body missing expected fields (`sha`, `commit.message`, `author.login`) | Log unexpected API shape; skip GitHub findings |
 
 ---
 
 ## Private Helper Functions
 
 ```python
+def _validate_guardrails(guardrails: dict) -> str | None:
+    # returns an error message string if invalid, None if valid
+    ...
+
 def _fetch_commits(anchor_sha: str, max_commits: int) -> list[dict]:
     # GET /repos/{GITHUB_REPO}/commits?sha={anchor_sha}&per_page={max_commits}
     # anchor_sha is release_sha when provided, otherwise GITHUB_BRANCH (HEAD)
     ...
 
-def _fetch_changed_files(sha: str) -> list[str]:
-    # GET /repos/{GITHUB_REPO}/commits/{sha} — returns filenames only
+def _fetch_changed_files(sha: str, max_files: int) -> list[str]:
+    # GET /repos/{GITHUB_REPO}/commits/{sha} — returns filenames only, capped at max_files
     ...
 
 def _trim_commit(raw: dict) -> dict:
@@ -118,9 +151,21 @@ File: `agents/tests/test_github_extractor.py`
 | 4 | `test_author_email_is_stripped` | Raw GitHub response includes author email → returned dict has no email field anywhere |
 | 5 | `test_release_sha_used_as_walk_anchor` | `release_sha` provided → fetch called with `sha=release_sha`, not `sha=GITHUB_BRANCH` |
 | 6 | `test_message_trimmed_to_first_line_and_capped` | Multi-line commit message → only first line returned, capped at `GITHUB_MSG_MAX_LEN` |
-| 7 | `test_max_commits_guardrail_is_respected` | Pass `guardrails={"max_commits": 3}` with API returning 10 commits → fetch called with `per_page=3`, `commit_count=3` |
-| 8 | `test_max_files_per_commit_guardrail_is_respected` | Commit detail returns 50 changed files; `GITHUB_MAX_FILES_PER_COMMIT=5` → `changed_files` list has exactly 5 entries |
-| 9 | `test_record_agent_run_called_on_every_return` | Mock `record_agent_run` — assert it is called for both completed and no_data paths |
+| 7 | `test_max_commits_guardrail_is_respected` | `guardrails={"max_commits": 3}` → fetch called with `per_page=3`, `commit_count=3` |
+| 8 | `test_max_files_per_commit_guardrail_is_respected` | API returns 50 files for a commit; `guardrails={"max_files_per_commit": 5}` → `changed_files` has exactly 5 entries |
+| 9 | `test_missing_token_returns_unauthenticated` | `GITHUB_TOKEN` is empty → `status="unauthenticated"`, no HTTP call made |
+| 10 | `test_401_response_returns_unauthenticated` | API returns 401 → `status="unauthenticated"` |
+| 11 | `test_403_response_returns_unauthorized` | API returns 403 → `status="unauthorized"` |
+| 12 | `test_404_response_returns_not_found` | API returns 404 → `status="not_found"` |
+| 13 | `test_429_response_returns_rate_limited` | API returns 429 → `status="rate_limited"` |
+| 14 | `test_5xx_response_returns_server_error` | API returns 500 → `status="server_error"` |
+| 15 | `test_timeout_returns_timeout` | `requests` raises `Timeout` → `status="timeout"` |
+| 16 | `test_connection_error_returns_network_error` | `requests` raises `ConnectionError` → `status="network_error"` |
+| 17 | `test_invalid_max_commits_type_returns_invalid_input` | `guardrails={"max_commits": "three"}` → `status="invalid_input"`, no HTTP call made |
+| 18 | `test_invalid_release_sha_format_returns_invalid_input` | `guardrails={"release_sha": "not-a-sha!!"}` → `status="invalid_input"`, no HTTP call made |
+| 19 | `test_negative_max_files_returns_invalid_input` | `guardrails={"max_files_per_commit": -1}` → `status="invalid_input"`, no HTTP call made |
+| 20 | `test_missing_response_fields_returns_schema_error` | API returns commit objects missing `author.login` → `status="schema_error"` |
+| 21 | `test_record_agent_run_called_on_every_return` | Mock `record_agent_run` — assert called for both `completed` and `no_data` paths |
 
 All HTTP calls mocked with `unittest.mock.patch`. No real GitHub API calls in tests.
 
@@ -131,7 +176,7 @@ All HTTP calls mocked with `unittest.mock.patch`. No real GitHub API calls in te
 | File | Change |
 |---|---|
 | `agents/github_extractor.py` | New — implementation |
-| `agents/tests/test_github_extractor.py` | New — 7 TDD tests |
+| `agents/tests/test_github_extractor.py` | New — 21 TDD tests |
 | `agents/specs/DEPENDENCY_MAP.md` | Update — add `github_extractor` row and new config constants |
 | `agents/.env.example` | Add `GITHUB_REPO`, `GITHUB_TOKEN`, `GITHUB_BRANCH` entries |
 
@@ -139,9 +184,10 @@ All HTTP calls mocked with `unittest.mock.patch`. No real GitHub API calls in te
 
 ## Acceptance Criteria
 
-- [ ] All 9 tests green
-- [ ] Full test suite green (no regressions — currently 25 tests)
+- [ ] All 21 tests green
+- [ ] Full test suite green (no regressions — currently 54 tests)
 - [ ] No real GitHub API calls in tests (all mocked)
 - [ ] `record_agent_run` called on every return path
+- [ ] Guardrail validation runs before any HTTP call
 - [ ] No hardcoded values — all config from `agents/config.py`
 - [ ] No cross-feature imports — all shared helpers from `patterns.py`, `sentry_utils.py`, `config.py`


### PR DESCRIPTION
- agents/config.py: 9 new shared status constants for all HTTP error cases (invalid_input, unauthenticated, unauthorized, not_found, rate_limited, server_error, timeout, network_error, schema_error) — same pattern as STATUS_COMPLETED; prevents silent misspellings
- agents/specs/d4_github_extractor.md: spec signed off; filtering pipeline rewritten — guardrail validation and token check run before any HTTP call; error return shape added; rule 9 added; test count corrected to 54; 21 TDD tests cover all exit conditions