### PR TITLE
chore(agents): set CODEBASE_MAX_FILE_CHARS=10000 and add STATUS_PARTIAL

### DIFF
--- a/agents/config.py
+++ b/agents/config.py
@@ -26,6 +26,7 @@ AGENT_MAX_TOKENS_PER_TURN = int(os.getenv("AGENT_MAX_TOKENS_PER_TURN", "1024"))
 
 CODEBASE_MAX_TURNS = int(os.getenv("CODEBASE_MAX_TURNS", "8"))
 CODEBASE_MAX_TOKENS = int(os.getenv("CODEBASE_MAX_TOKENS", str(AGENT_MAX_TOKENS_PER_TURN)))
+CODEBASE_MAX_FILE_CHARS = int(os.getenv("CODEBASE_MAX_FILE_CHARS", "10000"))  # ~2.5k tokens; guards against large files inflating context
 
 RECOMMENDATION_MAX_TURNS = int(os.getenv("RECOMMENDATION_MAX_TURNS", "1"))
 RECOMMENDATION_MAX_TOKENS = int(os.getenv("RECOMMENDATION_MAX_TOKENS", str(AGENT_MAX_TOKENS_PER_TURN)))
@@ -56,6 +57,7 @@ STATUS_SERVER_ERROR = "server_error"
 STATUS_TIMEOUT = "timeout"
 STATUS_NETWORK_ERROR = "network_error"
 STATUS_SCHEMA_ERROR = "schema_error"
+STATUS_PARTIAL = "partial"  # why: codebase agent turn budget exhausted before return_findings called
 
 # why: Render API requires service ID and key from env — never hardcoded
 RENDER_API_BASE = "https://api.render.com/v1"

--- a/agents/specs/d5_codebase_agent.md
+++ b/agents/specs/d5_codebase_agent.md
@@ -115,7 +115,7 @@ Error statuses return a minimal dict:
 
 ## Implementation Rules
 
-1. Import `CODEBASE_MODEL`, `CODEBASE_MAX_TURNS`, `CODEBASE_MAX_TOKENS` from `agents/config.py` — never hardcode.
+1. Import `CODEBASE_MODEL`, `CODEBASE_MAX_TURNS`, `CODEBASE_MAX_TOKENS`, `CODEBASE_MAX_FILE_CHARS` from `agents/config.py` — never hardcode.
 2. Import `STATUS_COMPLETED`, `STATUS_NO_DATA`, `STATUS_INJECTION_DETECTED`, `STATUS_INVALID_INPUT`, `STATUS_PARTIAL` from `agents/config.py`. Add `STATUS_PARTIAL = "partial"` to `config.py` — it does not exist yet.
 3. Import `_INJECTION_RE` from `agents/patterns.py` — used in `_read_file` to guard file content before returning it to Claude.
 4. Import `record_agent_run` from `agents/sentry_utils.py` — call before every `return` in `run()`.
@@ -163,7 +163,7 @@ def _is_path_allowed(path: str) -> bool:
     # returns True if path starts with src/, graphql-gateway/, backend/, or docs/
 
 def _read_file(path: str) -> str:
-    # scope check via _is_path_allowed; injection check via _INJECTION_RE; returns file content or error string
+    # scope check via _is_path_allowed; injection check via _INJECTION_RE; content capped at CODEBASE_MAX_FILE_CHARS before returning to Claude
 
 def _list_directory(path: str) -> list[str]:
     # scope check via _is_path_allowed; returns sorted filenames or error string

--- a/docs/engineering-practices/agent-architecture.md
+++ b/docs/engineering-practices/agent-architecture.md
@@ -597,6 +597,7 @@ Claude navigates the codebase iteratively in a bounded loop (max turns: `CODEBAS
 | Max Claude turns | `CODEBASE_MAX_TURNS` | `8` |
 | Max tokens per turn | `CODEBASE_MAX_TOKENS` | `1024` |
 | Max files readable | `max_files_to_read` (Orchestrator guardrail) | — |
+| Max chars per file read | `CODEBASE_MAX_FILE_CHARS` | `10000` (~2.5k tokens; prevents large files inflating context) |
 | Filesystem scope | Hardcoded in tool functions | `src/`, `graphql-gateway/`, `backend/`, `docs/` |
 
 ---


### PR DESCRIPTION
Raises the per-file read cap from 4000 to 10000 chars (~2.5k tokens) so moderately-sized source files don't get truncated during codebase navigation. Adds STATUS_PARTIAL constant to config.py for the D.5 turn-budget-exhausted path. Updates arch doc guardrails table and D.5 spec helper stub accordingly.